### PR TITLE
fix: default value of file upload on remove

### DIFF
--- a/src/components/Questions/FileUpload/FileUpload.jsx
+++ b/src/components/Questions/FileUpload/FileUpload.jsx
@@ -30,10 +30,10 @@ function FileUpload(props) {
     (props.component.validation?.validation_max_file_size?.isActive &&
       props.component.validation?.validation_max_file_size?.max_size) ||
     -1;
-  
+
   // Limit to validation value or 10MB (10240 KB), whichever is smaller
   const IMAGE_MAX_SIZE_KB = 10240; // 10MB
-  const maxFileSize = validationMaxSize > 0 
+  const maxFileSize = validationMaxSize > 0
     ? Math.min(validationMaxSize, IMAGE_MAX_SIZE_KB)
     : IMAGE_MAX_SIZE_KB;
 
@@ -157,7 +157,7 @@ function FileUpload(props) {
           <span>
             &nbsp;{selectedFile.name} - {Math.round(selectedFile.size / 1024)}K
           </span>
-       
+
           <Button
             disabled={isUploading}
             sx={{
@@ -224,7 +224,7 @@ function FileUpload(props) {
               dispatch(
                 valueChange({
                   componentCode: props.component.qualifiedCode,
-                  value: null,
+                  value: undefined,
                 })
               )
             }


### PR DESCRIPTION
fix for https://trello.com/c/63LjDj3Y/59-save-and-continue-later-the-user-is-not-able-to-save-the-survey-and-gets-500-error