### PR TITLE
feat: streamline editable survey components with onBlur save

### DIFF
--- a/src/components/manage/Survey/EditableSurveyDescription.jsx
+++ b/src/components/manage/Survey/EditableSurveyDescription.jsx
@@ -76,11 +76,13 @@ export const EditableSurveyDescription = ({
             showIcon={false}>
               <Typography
                 variant="caption"
+                onClick={isEditable ? handleEditClick : undefined}
                 sx={{
                   pr: 3,
                   pl: 1,
                   color: description ? "inherit" : "gray",
                   flexGrow: 1,
+                  cursor: isEditable ? "pointer" : "default",
                 }}
                 className={styles.truncatedText}
               >
@@ -90,11 +92,13 @@ export const EditableSurveyDescription = ({
           ) : (
             <Typography
               variant="caption"
+              onClick={isEditable ? handleEditClick : undefined}
               sx={{
                 pr: 3,
                 pl: 1,
                 color: description ? "inherit" : "gray",
                 flexGrow: 1,
+                cursor: isEditable ? "pointer" : "default",
               }}
               className={styles.truncatedText}
             >

--- a/src/components/manage/Survey/EditableSurveyDescription.jsx
+++ b/src/components/manage/Survey/EditableSurveyDescription.jsx
@@ -2,7 +2,7 @@ import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
 import { useState } from "react";
 import styles from "./Survey.module.css";
 import { truncateWithEllipsis } from "~/utils/design/utils";
-import { Edit } from "@mui/icons-material";
+import { Edit, Check } from "@mui/icons-material";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
@@ -45,7 +45,7 @@ export const EditableSurveyDescription = ({
       {isDescriptionEditing ? (
         <>
           <TextField
-            sx={{ px: 3, mr: 6 }}
+            sx={{ px: 3 }}
             value={description}
             onChange={handleDescriptionChange}
             onKeyDown={handleKeyDown}
@@ -56,6 +56,13 @@ export const EditableSurveyDescription = ({
             multiline
             rows={3}
           />
+          <IconButton
+            className={`${styles.saveIcon}`}
+            onClick={handleSave}
+            sx={{ ml: 1 }}
+          >
+            <Check sx={{ color: "gray" }} />
+          </IconButton>
         </>
       ) : (
         <>

--- a/src/components/manage/Survey/EditableSurveyDescription.jsx
+++ b/src/components/manage/Survey/EditableSurveyDescription.jsx
@@ -2,7 +2,7 @@ import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
 import { useState } from "react";
 import styles from "./Survey.module.css";
 import { truncateWithEllipsis } from "~/utils/design/utils";
-import { Edit, Check } from "@mui/icons-material";
+import { Edit } from "@mui/icons-material";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
@@ -45,23 +45,17 @@ export const EditableSurveyDescription = ({
       {isDescriptionEditing ? (
         <>
           <TextField
-            sx={{ px: 3 }}
+            sx={{ px: 3, mr: 6 }}
             value={description}
             onChange={handleDescriptionChange}
             onKeyDown={handleKeyDown}
+            onBlur={handleSave}
             autoFocus
             variant="standard"
             fullWidth
             multiline
             rows={3}
           />
-          <IconButton
-            className={`${styles.saveIcon}`}
-            onClick={handleSave}
-            sx={{ ml: 1 }}
-          >
-            <Check sx={{ color: "gray" }} />
-          </IconButton>
         </>
       ) : (
         <>

--- a/src/components/manage/Survey/EditableSurveyTitle.jsx
+++ b/src/components/manage/Survey/EditableSurveyTitle.jsx
@@ -70,6 +70,7 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
 
           <Typography
             variant="h5"
+            onClick={isEditable ? handleEditClick : undefined}
             sx={{
               pr: 3,
               pl: 1,
@@ -78,7 +79,8 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
               display: "-webkit-box",
               WebkitLineClamp: "2",
               WebkitBoxOrient: "vertical",
-              flexGrow: 1
+              flexGrow: 1,
+              cursor: isEditable ? "pointer" : "default",
             }}
           >
             {title}

--- a/src/components/manage/Survey/EditableSurveyTitle.jsx
+++ b/src/components/manage/Survey/EditableSurveyTitle.jsx
@@ -1,7 +1,7 @@
 import { Box, IconButton, TextField, Typography } from "@mui/material";
 import { useState } from "react";
 import styles from "./Survey.module.css";
-import { Edit } from "@mui/icons-material";
+import { Edit, Check } from "@mui/icons-material";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
@@ -42,7 +42,7 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
       {isEditing ? (
         <>
           <TextField
-            sx={{ px: 3, mr: 6, flexGrow: 1 }}
+            sx={{ px: 3, flexGrow: 1 }}
             value={title}
             onChange={handleTitleChange}
             onKeyDown={handleKeyDown}
@@ -54,6 +54,13 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
               style: { color: "white" },
             }}
           />
+          <IconButton
+            className={styles.saveIcon}
+            onClick={handleSave}
+            sx={{ ml: 1 }}
+          >
+            <Check sx={{ color: "white" }} />
+          </IconButton>
         </>
       ) : (
         <>

--- a/src/components/manage/Survey/EditableSurveyTitle.jsx
+++ b/src/components/manage/Survey/EditableSurveyTitle.jsx
@@ -1,7 +1,7 @@
 import { Box, IconButton, TextField, Typography } from "@mui/material";
 import { useState } from "react";
 import styles from "./Survey.module.css";
-import { Edit, Check } from "@mui/icons-material";
+import { Edit } from "@mui/icons-material";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
@@ -42,10 +42,11 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
       {isEditing ? (
         <>
           <TextField
-            sx={{ px: 3, flexGrow: 1 }}
+            sx={{ px: 3, mr: 6, flexGrow: 1 }}
             value={title}
             onChange={handleTitleChange}
             onKeyDown={handleKeyDown}
+            onBlur={handleSave}
             autoFocus
             variant="standard"
             fullWidth
@@ -53,13 +54,6 @@ export const EditableSurveyTitle = ({ survey, onSave, isEditable = true }) => {
               style: { color: "white" },
             }}
           />
-          <IconButton
-            className={styles.saveIcon}
-            onClick={handleSave}
-            sx={{ ml: 1 }}
-          >
-            <Check sx={{ color: "white" }} />
-          </IconButton>
         </>
       ) : (
         <>


### PR DESCRIPTION
## Summary
- Remove save button from EditableSurveyTitle and EditableSurveyDescription
- Add onBlur save functionality for a smoother editing experience

## Test plan
- [ ] Verify survey title saves on blur (clicking away from the field)
- [ ] Verify survey description saves on blur
- [ ] Verify no save button is shown