### PR TITLE
fix: action toolbar icons not responding to hover

### DIFF
--- a/src/components/Group/GroupDesign.module.css
+++ b/src/components/Group/GroupDesign.module.css
@@ -106,6 +106,7 @@
   justify-content: space-between;
   align-items: center;
   justify-content: end;
+  z-index: 1;
 }
 
 .headerContent {

--- a/src/components/Question/QuestionDesign.module.css
+++ b/src/components/Question/QuestionDesign.module.css
@@ -75,6 +75,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 1;
 }
 
 .highlight {


### PR DESCRIPTION
## Summary
- Add `z-index: 1` to `.contentContainer` in both `QuestionDesign.module.css` and `GroupDesign.module.css`
- The action icons (delete, duplicate, verify) were overlapped by sibling DOM elements, making them only clickable from the very top edge

## Test plan
- [ ] Hover over a question — delete, duplicate, and settings icons should respond across their entire area
- [ ] Hover over a group/page header — delete icon should respond across its entire area
- [ ] Verify icons don't interfere with the drag handle or title

🤖 Generated with [Claude Code](https://claude.com/claude-code)