### PR TITLE
fix: sidebar icon ripple area and active background

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+## Project Overview
+Qlarr Frontend is a React-based web application for creating, managing, and running surveys using the Qlarr Survey Engine DSL. It provides:
+1. A WYSIWYG editor for building surveys in the Survey Engine DSL
+2. A survey renderer used in both web and Android apps
+3. Admin GUI for survey management, user management, login, cloning, etc.
+
+Surveys are defined as JSON (UI-agnostic components) with JavaScript instructions for complex logic.
+
+## Tech Stack
+- **Framework**: React 18, JavaScript (JSX — no TypeScript)
+- **Build tool**: Vite 5
+- **UI library**: MUI v5 with Emotion CSS-in-JS
+- **State management**: Redux Toolkit (two stores: `runStore` for survey responses, `manageStore` for survey editing)
+- **Routing**: React Router v6
+- **Forms**: React Hook Form + Yup validation
+- **HTTP client**: Axios with JWT auth interceptors (access + refresh token rotation)
+- **i18n**: i18next — supported languages: en, ar, de, es, pt, fr, nl (RTL support for Arabic)
+- **Rich text editor**: TipTap
+- **Drag & drop**: react-dnd
+
+## Project Structure
+```
+src/
+  components/    # UI components organized by feature (auth, common, design, manage, run, Questions)
+  pages/         # Page-level components (ManageSurvey, RunSurvey, Dashboard, etc.)
+  state/         # Redux slices (designState, runState, editState, templateState)
+  services/      # API service classes (AuthService, SurveyService, DesignService, RunService, etc.)
+  networking/    # Axios instances (authenticatedApi, publicApi) and endpoint definitions
+  hooks/         # Custom React hooks (useBoolean, useResponsive, useNamespaceLoader, etc.)
+  theme/         # MUI theme config (palette, typography, shadows, RTL)
+  constants/     # App constants (design rules, roles, component types, validation options)
+  utils/         # Utility functions (error processing, date formatting, design utilities)
+  layouts/       # Layout components
+  assets/        # Static assets
+  styles/        # Global CSS
+```
+
+**Entry points**: `index.jsx` → `App.jsx` → `Web.jsx` (web) / `Android.jsx` (android) → `routes.js`
+**Store config**: `store.js` (defines both `runStore` and `manageStore`)
+
+## Path Aliases
+`~/` maps to `src/` (configured in `jsconfig.json`)
+
+## Development
+- **Package manager**: npm
+- **Node version**: 16+
+- Copy `.env.example` to `.env` and set `VITE_BE_URL` to point to the backend API
+
+### Commands
+| Command | Purpose |
+|---------|---------|
+| `npm start` | Dev server on port 3000 |
+| `npm run build` | Production build |
+| `npm run build-staging` | Staging build (ES2018, sourcemaps) |
+| `npm run build-android` | Android build (ES2015, minified) |
+| `npm run build-android-debuggable` | Android debug build |
+| `npm run serve` | Preview production build |
+
+### Environment Variables
+```
+VITE_FRONT_END_HOST=localhost:3000
+VITE_PROTOCOL=http
+VITE_BE_URL=http://localhost:8080/
+```
+
+## Code Conventions
+- **Components**: Functional only, `React.memo` for optimization, PascalCase file/folder names
+- **Barrel exports**: `index.jsx` files in component folders
+- **Styling**: MUI `sx` prop and CSS modules (`.module.css`)
+- **Forms**: RHF wrapper components in `components/hook-form/` (RHFTextField, RHFSelect, RHFCheckbox, etc.)
+- **State**: Redux Toolkit slices in `state/`, custom debounced save middleware for auto-saving
+- **Services**: Class-based service layer in `services/` with a `BaseService` for common error handling
+- **Auth**: JWT Bearer tokens via Axios interceptors, automatic token refresh on 401
+- **Lazy loading**: Route-based with React.lazy + Suspense
+
+## PR Conventions
+- PR titles MUST use semantic/conventional commit prefixes (enforced by `.github/workflows/lint-pr.yaml`)
+- Valid prefixes: `fix:`, `feat:`, `refactor:`, `chore:`, `docs:`, `style:`, `perf:`, `test:`, `build:`, `ci:`, `revert:`
+- Example: `fix: sidebar icon ripple area` or `feat: add new survey type`
+
+## Deployment
+- **Docker**: Multi-stage Dockerfile (Node 18 build → Nginx serve on port 80)
+- **Production**: Use the docker-compose from the backend repo to deploy both frontend and backend

--- a/src/components/design/SideTabs/index.jsx
+++ b/src/components/design/SideTabs/index.jsx
@@ -30,12 +30,20 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
   const tabAvailable = (tab) => availablePages.indexOf(tab) !== -1;
   const { t } = useTranslation(NAMESPACES.DESIGN_CORE);
   const dispatch = useDispatch();
-  const getTabButtonStyle = (selected) => ({
+  const getTabButtonSx = (selected) => ({
     minWidth: "auto",
-    margin: "0px !important",
-    padding: "12px 0px",
-    backgroundColor: selected ? "#2d3cb2" : undefined,
+    padding: "0px",
+    height: "70px",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: selected ? "#2d3cb2" : "transparent",
     color: "#fff",
+    "&:hover": {
+      backgroundColor: selected ? "#2d3cb2" : "rgba(255,255,255,0.1)",
+    },
+    "& .MuiTouchRipple-root": {
+      color: "rgba(255,255,255,0.3)",
+    },
   });
 
   const versionDto = useSelector((state) => {
@@ -55,7 +63,7 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
           <>
             <SideTab
               tooltip={t("design")}
-              style={getTabButtonStyle(
+              buttonSx={getTabButtonSx(
                 selectedPage == MANAGE_SURVEY_LANDING_PAGES.DESIGN && designMode == DESIGN_SURVEY_MODE.DESIGN
               )}
               link={routes.designSurvey.replace(":surveyId", surveyId)}
@@ -67,7 +75,7 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
             />
             <SideTab
               tooltip={t("theme")}
-              style={getTabButtonStyle(selectedPage == MANAGE_SURVEY_LANDING_PAGES.DESIGN && designMode == DESIGN_SURVEY_MODE.THEME)}
+              buttonSx={getTabButtonSx(selectedPage == MANAGE_SURVEY_LANDING_PAGES.DESIGN && designMode == DESIGN_SURVEY_MODE.THEME)}
               icon={<Palette sx={{ color: "#fff" }} />}
               link={routes.designSurvey.replace(":surveyId", surveyId)}
               onClick={() => {
@@ -78,7 +86,7 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
             <SideTab
               tooltip={t("translation")}
               link={routes.designSurvey.replace(":surveyId", surveyId)}
-              style={getTabButtonStyle(
+              buttonSx={getTabButtonSx(
                 selectedPage == MANAGE_SURVEY_LANDING_PAGES.DESIGN && designMode == DESIGN_SURVEY_MODE.LANGUAGES
               )}
               icon={<Translate sx={{ color: "#fff" }} />}
@@ -92,7 +100,7 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
         {tabAvailable(MANAGE_SURVEY_LANDING_PAGES.SETTINGS) && (
           <SideTab
             tooltip={t("settings")}
-            style={getTabButtonStyle(
+            buttonSx={getTabButtonSx(
               selectedPage == MANAGE_SURVEY_LANDING_PAGES.SETTINGS
             )}
             link={routes.editSurvey.replace(":surveyId", surveyId)}
@@ -112,7 +120,7 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
         {tabAvailable(MANAGE_SURVEY_LANDING_PAGES.RESPONSES) && (
           <SideTab
             tooltip={t("responses")}
-            style={getTabButtonStyle(
+            buttonSx={getTabButtonSx(
               selectedPage == MANAGE_SURVEY_LANDING_PAGES.RESPONSES
             )}
             link={routes.responses.replace(":surveyId", surveyId)}
@@ -131,21 +139,21 @@ function SideTabs({ selectedPage, onPageChange, availablePages, surveyId }) {
 
 export default React.memo(SideTabs);
 
-function SideTab({ tooltip, style, link, onClick, icon, isLink = true }) {
+function SideTab({ tooltip, buttonSx, link, onClick, icon, isLink = true }) {
   return (
     <CustomTooltip showIcon={false} title={tooltip} placement="right">
       {isLink ? (
         <Link to={link} onClick={() => onClick()}>
-          <ListItem disablePadding style={style}>
-            <ListItemButton>
-              <ListItemIcon>{icon}</ListItemIcon>
+          <ListItem disablePadding>
+            <ListItemButton sx={buttonSx}>
+              <ListItemIcon sx={{ minWidth: "auto", justifyContent: "center", marginRight: 0 }}>{icon}</ListItemIcon>
             </ListItemButton>
           </ListItem>
         </Link>
       ) : (
-        <ListItem disablePadding style={style}>
-          <ListItemButton onClick={() => onClick()}>
-            <ListItemIcon>{icon}</ListItemIcon>
+        <ListItem disablePadding>
+          <ListItemButton sx={buttonSx} onClick={() => onClick()}>
+            <ListItemIcon sx={{ minWidth: "auto", justifyContent: "center", marginRight: 0 }}>{icon}</ListItemIcon>
           </ListItemButton>
         </ListItem>
       )}


### PR DESCRIPTION
## Summary
- Move active background styling from `ListItem` to `ListItemButton` so all icons consistently show the active state
- Set button height to 70px so the ripple effect covers the full icon area
- Center icons horizontally and vertically by overriding theme's `marginRight` on `ListItemIcon`

## Test plan
- [ ] Click each sidebar icon and verify the active background (#2d3cb2) appears
- [ ] Hover each icon and verify the ripple fills the full 70px height
- [ ] Verify the red unpublished-changes dot on Settings still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)