### PR TITLE
fix: pointer-events on question design overlay and action toolbar

### DIFF
--- a/src/components/Question/QuestionDesign.module.css
+++ b/src/components/Question/QuestionDesign.module.css
@@ -76,6 +76,11 @@
   justify-content: space-between;
   align-items: center;
   z-index: 1;
+  pointer-events: none;
+}
+
+.moveBox {
+  pointer-events: auto;
 }
 
 .highlight {

--- a/src/components/design/ActionToolbar/ActionToolbar.module.css
+++ b/src/components/design/ActionToolbar/ActionToolbar.module.css
@@ -7,6 +7,7 @@
 
 .statusIcon {
   cursor: default;
+  pointer-events: auto;
 }
 
 .questionContainer {


### PR DESCRIPTION
## Summary
- Set `pointer-events: none` on the question design header overlay to prevent it from blocking interactions with underlying elements
- Add `moveBox` class with `pointer-events: auto` to re-enable drag handle interaction
- Enable `pointer-events: auto` on the status icon in the action toolbar

## Test plan
- [ ] Verify question drag handles still work in the design editor
- [ ] Verify action toolbar status icons are interactive
- [ ] Verify clicks pass through the header overlay to elements beneath it

🤖 Generated with [Claude Code](https://claude.com/claude-code)