### PR TITLE
fix: remove delete button from thanks group

### DIFF
--- a/src/components/design/ActionToolbar/index.jsx
+++ b/src/components/design/ActionToolbar/index.jsx
@@ -216,7 +216,7 @@ function ActionToolbar({ code, isGroup, parentCode, showActions }) {
           </IconButton>
         </CustomTooltip>
       )}
-      {(isGroup || showActions) && (
+      {(isGroup || showActions) && type !== "end" && (
         <>
           <CustomTooltip title={t("delete")} showIcon={false}>
             <IconButton


### PR DESCRIPTION
## Summary
- Hide the delete button for the end/thanks group in the survey designer
- The thanks group is a required part of every survey and should not be deletable
- Adds a `type !== "end"` check to the delete action visibility condition in `ActionToolbar`