### PR TITLE
refactor: extract design state reducer logic into pure, testable functions

### DIFF
--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,4 +1,4 @@
-import { colorToThemeMode } from "~/components/Questions/utils";
+import { colorToThemeMode } from "~/utils/design/colorUtils";
 
 export const BG_COLOR = "#dfe2ef";
 export const TEXT_COLOR = "#091133";

--- a/src/state/design/addInstructions.js
+++ b/src/state/design/addInstructions.js
@@ -704,7 +704,7 @@ export const addAnswerInstructions = (
   }
 };
 
-const addValidationEquation = (state, qualifiedCode, rule) => {
+export const addValidationEquation = (state, qualifiedCode, rule) => {
   const component = state[qualifiedCode];
   const validationInstruction = validationEquation(
     qualifiedCode,
@@ -716,7 +716,7 @@ const addValidationEquation = (state, qualifiedCode, rule) => {
 };
 
 // there is always an assumption that instructionList exists!!!
-const editInstruction = (componentState, instruction) => {
+export const editInstruction = (componentState, instruction) => {
   const index = componentState.instructionList.findIndex(
     (el) => el.code === instruction.code
   );
@@ -727,7 +727,7 @@ const editInstruction = (componentState, instruction) => {
   }
 };
 
-const scqSkipEquations = (qualifiedCode, component) => {
+export const scqSkipEquations = (qualifiedCode, component) => {
   const skipLogic = component.skip_logic || [];
   const instructionList = [];
 
@@ -769,7 +769,7 @@ const scqSkipEquations = (qualifiedCode, component) => {
   return instructionList;
 };
 
-const validationEquation = (qualifiedCode, component, key, validation) => {
+export const validationEquation = (qualifiedCode, component, key, validation) => {
   if (
     !validation.isActive ||
     (key == "validation_not_contains" && !validation.not_contains)
@@ -928,7 +928,7 @@ const validationEquation = (qualifiedCode, component, key, validation) => {
   }
 };
 
-const booleanActiveInstruction = (key, instructionText) => {
+export const booleanActiveInstruction = (key, instructionText) => {
   return {
     code: key,
     text: instructionText,
@@ -937,7 +937,7 @@ const booleanActiveInstruction = (key, instructionText) => {
   };
 };
 
-const requiredText = (qualifiedCode, component) => {
+export const requiredText = (qualifiedCode, component) => {
   if (
     component.type == "file_upload" ||
     component.type == "signature" ||
@@ -980,7 +980,7 @@ const requiredText = (qualifiedCode, component) => {
   }
 };
 
-const isValidRegex = (regex) => {
+export const isValidRegex = (regex) => {
   if (!regex) {
     return false;
   }
@@ -1163,7 +1163,7 @@ export const updateRandomByRule = (
   }
 };
 
-const getQuestionType = (state, code) => {
+export const getQuestionType = (state, code) => {
   const match = code.match(/^Q[a-z0-9_]+/);
   const captured = match ? match[0] : null;
   if (captured) {
@@ -1209,7 +1209,7 @@ export const conditionalRelevanceEquation = (logic, rule, state) => {
   }
 };
 
-const jsonToJs = (json, nested, getComponentType, getQuestionType) => {
+export const jsonToJs = (json, nested, getComponentType, getQuestionType) => {
   if (!json || typeof json !== "object") {
     return "";
   }
@@ -1380,11 +1380,11 @@ const jsonToJs = (json, nested, getComponentType, getQuestionType) => {
   }
 };
 
-const wrapIfNested = (nested, text) => {
+export const wrapIfNested = (nested, text) => {
   return (nested ? "(" : "") + text + (nested ? ")" : "");
 };
 
-const capture = (value, type) => {
+export const capture = (value, type) => {
   if (type == "time") {
     return `QlarrScripts.sqlDateTimeToDate(\"1970-01-01 ${integerToTime(
       value
@@ -1406,7 +1406,7 @@ const capture = (value, type) => {
   }
 };
 
-const integerToTime = (time) => {
+export const integerToTime = (time) => {
   let hours = Math.floor(time / 3600);
   let hoursString = hours >= 10 && hours <= 23 ? "" + hours : "0" + hours;
   let minutes = (time % 3600) / 60;
@@ -1415,7 +1415,7 @@ const integerToTime = (time) => {
   return hoursString + ":" + minutesString + ":00";
 };
 
-const toSqlDateTime = (date) => {
+export const toSqlDateTime = (date) => {
   return (
     date.getFullYear() +
     "-" +
@@ -1431,7 +1431,7 @@ const toSqlDateTime = (date) => {
   );
 };
 
-const toSqlDateTimeIgnoreTime = (date) => {
+export const toSqlDateTimeIgnoreTime = (date) => {
   return (
     date.getFullYear() +
     "-" +
@@ -1455,7 +1455,7 @@ export const fileTypesToMimesArray = (fileTypes) => {
   return accepted;
 };
 
-const acceptedFileTypes = (fileType) => {
+export const acceptedFileTypes = (fileType) => {
   switch (fileType) {
     case "presentation":
       return [
@@ -1604,7 +1604,7 @@ export const processValidation = (state, code, rule, modifyEquation = true) => {
   }
 };
 
-const cleanupValidationData = (component, key, validation) => {
+export const cleanupValidationData = (component, key, validation) => {
   switch (key) {
     case "validation_required":
     case "validation_one_response_per_col":

--- a/src/state/design/componentFactories.js
+++ b/src/state/design/componentFactories.js
@@ -1,0 +1,439 @@
+export const createGroup = (groupType, gId) => {
+  let code = `G${gId}`;
+  let state = {
+    groupType,
+  };
+  let newGroup = {
+    code,
+    qualifiedCode: code,
+    type: groupType.toLowerCase(),
+    groupType,
+  };
+  return { newGroup, state };
+};
+
+export const isDisplay = (type) => {
+  return ["text_display", "image_display", "video_display"].indexOf(type) > -1;
+};
+
+export const createQuestion = (type, qId, lang) => {
+  let code = `Q${qId}`;
+  let returnObj = {};
+  let state = { type };
+  let newQuestion = { code: `Q${qId}`, qualifiedCode: `Q${qId}`, type };
+  returnObj[code] = state;
+  returnObj.question = newQuestion;
+  switch (type) {
+    case "text":
+      state.maxChars = 30;
+      state.showHint = true;
+      break;
+    case "number":
+      state.maxChars = 30;
+      state.showHint = true;
+      break;
+    case "email":
+      state.maxChars = 30;
+      state.showHint = true;
+      state.validation = {
+        validation_pattern_email: {
+          isActive: true,
+        },
+      };
+
+      break;
+    case "paragraph":
+      state.showHint = true;
+      break;
+    case "scq":
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "icon_scq":
+      state.columns = 3;
+      state.iconSize = "150";
+      state.spacing = 8;
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "image_scq":
+      state.columns = 3;
+      state.imageAspectRatio = 1;
+      state.spacing = 8;
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "multiple_text":
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+
+    case "mcq":
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "image_ranking":
+      state.columns = 3;
+      state.imageAspectRatio = 1;
+      state.spacing = 8;
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "ranking":
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "nps":
+      break;
+    case "icon_mcq":
+      state.columns = 3;
+      state.columns = 3;
+      state.iconSize = "150";
+      state.spacing = 8;
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "image_mcq":
+      state.columns = 3;
+      state.imageAspectRatio = 1;
+      state.spacing = 8;
+      returnObj[`Q${qId}A1`] = {};
+      returnObj[`Q${qId}A2`] = {};
+      returnObj[`Q${qId}A3`] = {};
+      state.children = [
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+        },
+      ];
+
+      break;
+    case "scq_icon_array":
+      returnObj[`Q${qId}Ac1`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}Ac2`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}Ac3`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}A1`] = {
+        type: "row",
+      };
+      returnObj[`Q${qId}A2`] = {
+        type: "row",
+      };
+      returnObj[`Q${qId}A3`] = {
+        type: "row",
+      };
+      state.children = [
+        {
+          code: "Ac1",
+          qualifiedCode: `Q${qId}Ac1`,
+          type: "column",
+        },
+        {
+          code: "Ac2",
+          qualifiedCode: `Q${qId}Ac2`,
+          type: "column",
+        },
+        {
+          code: "Ac3",
+          qualifiedCode: `Q${qId}Ac3`,
+          type: "column",
+        },
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+          type: "row",
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+          type: "row",
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+          type: "row",
+        },
+      ];
+
+      break;
+    case "scq_array":
+    case "mcq_array":
+      returnObj[`Q${qId}Ac1`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}Ac2`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}Ac3`] = {
+        type: "column",
+      };
+      returnObj[`Q${qId}A1`] = {
+        type: "row",
+      };
+      returnObj[`Q${qId}A2`] = {
+        type: "row",
+      };
+      returnObj[`Q${qId}A3`] = {
+        type: "row",
+      };
+      state.children = [
+        {
+          code: "Ac1",
+          qualifiedCode: `Q${qId}Ac1`,
+          type: "column",
+        },
+        {
+          code: "Ac2",
+          qualifiedCode: `Q${qId}Ac2`,
+          type: "column",
+        },
+        {
+          code: "Ac3",
+          qualifiedCode: `Q${qId}Ac3`,
+          type: "column",
+        },
+        {
+          code: "A1",
+          qualifiedCode: `Q${qId}A1`,
+          type: "row",
+        },
+        {
+          code: "A2",
+          qualifiedCode: `Q${qId}A2`,
+          type: "row",
+        },
+        {
+          code: "A3",
+          qualifiedCode: `Q${qId}A3`,
+          type: "row",
+        },
+      ];
+
+      break;
+    case "file_upload":
+    case "signature":
+    case "photo_capture":
+    case "video_capture":
+    case "barcode":
+      break;
+    case "date":
+      state.type = "date";
+      state.dateFormat = "YYYY/MM/DD";
+      state.maxDate = "";
+      state.minDate = "";
+
+      break;
+    case "date_time":
+      state.dateFormat = "YYYY/MM/DD";
+      state.fullDayFormat = false;
+      state.maxDate = "";
+      state.minDate = "";
+
+      break;
+    case "time":
+      state.fullDayFormat = false;
+      break;
+    case "autocomplete":
+    case "text_display":
+    case "video_display":
+    case "image_display":
+      break;
+    default:
+      break;
+  }
+  return returnObj;
+};
+
+export const questionDesignError = (question) => {
+  let errors = [];
+  switch (question.type) {
+    case "scq_icon_array":
+    case "scq_array":
+    case "mcq_array":
+      if (
+        !question.children ||
+        question.children.filter((child) => child.type == "row").length === 0
+      ) {
+        errors.push({
+          code: "insufficient_rows_min_1",
+          message: "must have at least 1 row",
+        });
+      }
+      if (
+        !question.children ||
+        question.children.filter((child) => child.type == "column").length < 2
+      ) {
+        errors.push({
+          code: "insufficient_cols_min_2",
+          message: "must have at least 2 columns",
+        });
+      }
+      break;
+    case "image_ranking":
+    case "ranking":
+    case "image_scq":
+    case "scq":
+    case "icon_scq":
+      if (!question.children || question.children.length < 2) {
+        errors.push({
+          code: "insufficient_options_min_2",
+          message: "must have at least 2 options",
+        });
+      }
+      break;
+
+    case "icon_mcq":
+    case "image_mcq":
+    case "multiple_text":
+    case "mcq":
+      if (!question.children || question.children.length < 1) {
+        errors.push({
+          code: "insufficient_options_min_1",
+          message: "must have at least 1 option",
+        });
+      }
+      break;
+  }
+  return errors;
+};

--- a/src/state/design/designState.js
+++ b/src/state/design/designState.js
@@ -49,797 +49,751 @@ const reservedKeys = [
   "skipScroll",
 ];
 
-export const designState = createSlice({
-  name: "designState",
-  initialState: { state: {} },
-  reducers: {
-    designStateReceived: (state, action) => {
-      const response = action.payload;
-      let newState = response.designerInput.state;
+// --- Extracted reducer logic ---
 
-      if (!newState.Survey.theme) {
-        newState.Survey.theme = defaultSurveyTheme;
-      }
+export const handleDesignStateReceived = (state, action) => {
+  const response = action.payload;
+  let newState = response.designerInput.state;
 
-      const newKeys = Object.keys(newState).filter(
-        (el) => !reservedKeys.includes(el)
-      );
-      const toBeRemoved = Object.keys(state).filter(
-        (el) => !reservedKeys.includes(el) && !newKeys.includes(el)
-      );
+  if (!newState.Survey.theme) {
+    newState.Survey.theme = defaultSurveyTheme;
+  }
 
-      if (!state.langInfo || response.overWriteLang) {
-        const defaultLang = newState.Survey.defaultLang || LANGUAGE_DEF.en;
-        const mainLang = defaultLang.code;
-        const lang = defaultLang.code;
-        const languagesList = [defaultLang].concat(
-          newState.Survey.additionalLang || []
-        );
-        state.langInfo = {
-          languagesList,
-          mainLang,
-          lang,
-          onMainLang: lang == mainLang,
-        };
-      }
+  const newKeys = Object.keys(newState).filter(
+    (el) => !reservedKeys.includes(el)
+  );
+  const toBeRemoved = Object.keys(state).filter(
+    (el) => !reservedKeys.includes(el) && !newKeys.includes(el)
+  );
 
-      toBeRemoved.forEach((key) => {
-        delete state[key];
-      });
-      const inCurrentSetup = state["setup"]?.code;
-      if (!newKeys.includes(inCurrentSetup)) {
-        delete state["setup"];
-      }
+  if (!state.langInfo || response.overWriteLang) {
+    const defaultLang = newState.Survey.defaultLang || LANGUAGE_DEF.en;
+    const mainLang = defaultLang.code;
+    const lang = defaultLang.code;
+    const languagesList = [defaultLang].concat(
+      newState.Survey.additionalLang || []
+    );
+    state.langInfo = {
+      languagesList,
+      mainLang,
+      lang,
+      onMainLang: lang == mainLang,
+    };
+  }
 
-      newKeys.forEach((key) => {
-        state[key] = newState[key];
-      });
-      state.versionDto = response.versionDto;
-      state.componentIndex = response.designerInput.componentIndexList;
-      state["latest"] = structuredClone(newState);
-      state.lastAddedComponent = null;
-      state.index = buildCodeIndex(state);
-    },
-    setup(state, action) {
-      const payload = action.payload;
-      // we want to ignore multiple clicks on the same setup button
-      // but acknowledge when we highlight or expand a specific section
+  toBeRemoved.forEach((key) => {
+    delete state[key];
+  });
+  const inCurrentSetup = state["setup"]?.code;
+  if (!newKeys.includes(inCurrentSetup)) {
+    delete state["setup"];
+  }
+
+  newKeys.forEach((key) => {
+    state[key] = newState[key];
+  });
+  state.versionDto = response.versionDto;
+  state.componentIndex = response.designerInput.componentIndexList;
+  state["latest"] = structuredClone(newState);
+  state.lastAddedComponent = null;
+  state.index = buildCodeIndex(state);
+};
+
+export const handleSetup = (state, action) => {
+  const payload = action.payload;
+  // we want to ignore multiple clicks on the same setup button
+  // but acknowledge when we highlight or expand a specific section
+  if (
+    payload.code != state.setup?.code ||
+    !isEquivalent(payload.rules, state.setup?.rules) ||
+    payload.highlighted
+  ) {
+    state.setup = action.payload;
+  }
+};
+
+export const handleChangeValidationValue = (state, action) => {
+  let payload = action.payload;
+  if (!state[payload.code]["validation"]) {
+    state[payload.code]["validation"] = {};
+  }
+  if (!state[payload.code]["validation"][payload.rule]) {
+    state[payload.code]["validation"][payload.rule] =
+      buildValidationDefaultData(payload.rule);
+  }
+  state[payload.code]["validation"][payload.rule][payload.key] =
+    payload.value;
+  processValidation(
+    state,
+    payload.code,
+    payload.rule,
+    payload.rule != "content"
+  );
+};
+
+export const handleResetSetup = (state) => {
+  const isInTranslationMode =
+    state.designMode === DESIGN_SURVEY_MODE.LANGUAGES;
+
+  if (state.langInfo && !isInTranslationMode) {
+    state.langInfo.lang = state.langInfo.mainLang;
+    state.langInfo.onMainLang = true;
+  }
+  if (!state.globalSetup) {
+    state.globalSetup = {};
+  }
+  delete state["setup"];
+
+  if (!isInTranslationMode) {
+    state.designMode = DESIGN_SURVEY_MODE.DESIGN;
+  }
+};
+
+export const handleSetDesignModeToDesign = (state) => {
+  handleResetSetup(state);
+  state.designMode = DESIGN_SURVEY_MODE.DESIGN;
+};
+
+export const handleSetDesignModeToLang = (state) => {
+  handleResetSetup(state);
+  handleSetup(state, { payload: languageSetup });
+  state.designMode = DESIGN_SURVEY_MODE.LANGUAGES;
+};
+
+export const handleSetDesignModeToTheme = (state) => {
+  handleResetSetup(state);
+  handleSetup(state, { payload: themeSetup });
+  state.designMode = DESIGN_SURVEY_MODE.THEME;
+};
+
+export const handleChangeAttribute = (state, action) => {
+  let payload = action.payload;
+  if (
+    action.payload.key == "content" ||
+    action.payload.key == "instructionList" ||
+    action.payload.key == "relevance" ||
+    action.payload.key == "resources"
+  ) {
+    throw "We are changing attributes way too much than we should";
+  }
+  if (!state[payload.code]) {
+    state[payload.code] = {};
+  }
+  const originalValue = state[payload.code][payload.key];
+
+  state[payload.code][payload.key] = payload.value;
+  if (action.payload.key == "maxChars") {
+    cleanupValidation(state, payload.code);
+  } else if (action.payload.key == "dateFormat") {
+    addMaskedValuesInstructions(payload.code, state[payload.code], state);
+  } else if (action.payload.key == "fullDayFormat") {
+    addMaskedValuesInstructions(payload.code, state[payload.code], state);
+  } else if (action.payload.key == "decimal_separator") {
+    addMaskedValuesInstructions(payload.code, state[payload.code], state);
+  } else if (
+    [
+      "randomize_questions",
+      "randomize_groups",
+      "randomize_options",
+      "randomize_rows",
+      "randomize_columns",
+    ].indexOf(action.payload.key) > -1
+  ) {
+    updateRandomByRule(
+      state[payload.code],
+      action.payload.key,
+      !originalValue || originalValue == "NONE"
+    );
+  }
+};
+
+export const handleChangeRelevance = (state, action) => {
+  let payload = action.payload;
+  state[payload.code].relevance = payload.value;
+  addRelevanceInstructions(state, payload.code, payload.value);
+};
+
+export const handleSetDefaultValue = (state, action) => {
+  const { code, selectedValue } = action.payload;
+  const component = state[code];
+  const valueInstruction = component.instructionList?.find(
+    (instruction) => instruction.code == "value"
+  );
+  if (valueInstruction) {
+    changeInstruction(component, {
+      ...valueInstruction,
+      text: selectedValue,
+      isActive: false,
+    });
+  }
+};
+
+export const handleCloneQuestion = (state, action) => {
+  const code = action.payload;
+  const survey = state.Survey;
+  const group = survey.children
+    ?.map((group) => state[group.code])
+    ?.filter(
+      (group) =>
+        group.children &&
+        group.children.findIndex((child) => child.code == code) !== -1
+    )?.[0];
+  if (!group) {
+    return;
+  }
+  const newQuestionId = "Q" + nextQuestionId(state, survey.children);
+  const questionChild = group.children.find((el) => el.code == code);
+  const newQuestion = {
+    type: questionChild.type,
+    code: newQuestionId,
+    qualifiedCode: newQuestionId,
+  };
+  creatNewState(state, state[code], newQuestionId, code, newQuestionId);
+  group.children.splice(
+    group.children.indexOf(questionChild) + 1,
+    0,
+    newQuestion
+  );
+  handleSetup(state, {
+    payload: { code: newQuestionId, rules: setupOptions(newQuestion.type) },
+  });
+  cleanupRandomRules(group);
+  state.index = buildCodeIndex(state);
+  state.focus = newQuestionId;
+};
+
+export const handleRemoveAnswer = (state, action) => {
+  const answerQualifiedCode = action.payload;
+  const codes = splitQuestionCodes(answerQualifiedCode);
+  let question = state[codes[0]];
+  question.children = question.children.filter(
+    (el) => el.code !== codes[1]
+  );
+  delete state[answerQualifiedCode];
+  // could be otherText
+  if (state.setup?.code?.includes(answerQualifiedCode)) {
+    handleResetSetup(state);
+  }
+  state.index = buildCodeIndex(state);
+  question.designErrors = questionDesignError(question);
+  cleanupValidation(state, codes[0]);
+  cleanupDefaultValue(question);
+  refreshEnumForSingleChoice(question, state);
+  refreshListForMultipleChoice(question, state);
+  addMaskedValuesInstructions(codes[0], question, state);
+  cleanupRandomRules(question);
+  addSkipInstructions(state, codes[0]);
+};
+
+export const handleAddNewAnswers = (state, action) => {
+  const questionCode = action.payload.questionCode;
+  const data = action.payload.data;
+  const type = action.payload.type;
+  let index = action.payload.index;
+  const question = state[questionCode];
+  const children =
+    question.children?.filter(
+      (it) => state[it.qualifiedCode].type == type
+    ) || [];
+  data.forEach((item, itemIndex) => {
+    if (item) {
+      const nextAnswer = children[index + 1];
       if (
-        payload.code != state.setup?.code ||
-        !isEquivalent(payload.rules, state.setup?.rules) ||
-        payload.highlighted
+        nextAnswer &&
+        nextAnswer.qualifiedCode &&
+        state[nextAnswer.qualifiedCode] &&
+        (!state[nextAnswer.qualifiedCode].content ||
+          !state[nextAnswer.qualifiedCode].content[state.langInfo.lang])
       ) {
-        state.setup = action.payload;
-      }
-    },
-    newVersionReceived(state, action) {
-      const payload = action.payload;
-      state.versionDto = payload;
-    },
-    changeValidationValue(state, action) {
-      let payload = action.payload;
-      if (!state[payload.code]["validation"]) {
-        state[payload.code]["validation"] = {};
-      }
-      if (!state[payload.code]["validation"][payload.rule]) {
-        state[payload.code]["validation"][payload.rule] =
-          buildValidationDefaultData(payload.rule);
-      }
-      state[payload.code]["validation"][payload.rule][payload.key] =
-        payload.value;
-      processValidation(
-        state,
-        payload.code,
-        payload.rule,
-        payload.rule != "content"
-      );
-    },
-    resetSetup(state) {
-      const isInTranslationMode =
-        state.designMode === DESIGN_SURVEY_MODE.LANGUAGES;
-
-      if (state.langInfo && !isInTranslationMode) {
-        state.langInfo.lang = state.langInfo.mainLang;
-        state.langInfo.onMainLang = true;
-      }
-      if (!state.globalSetup) {
-        state.globalSetup = {};
-      }
-      delete state["setup"];
-
-      if (!isInTranslationMode) {
-        state.designMode = DESIGN_SURVEY_MODE.DESIGN;
-      }
-    },
-    setDesignModeToDesign(state) {
-      designState.caseReducers.resetSetup(state);
-      state.designMode = DESIGN_SURVEY_MODE.DESIGN;
-    },
-    setDesignModeToLang(state) {
-      designState.caseReducers.resetSetup(state);
-      designState.caseReducers.setup(state, { payload: languageSetup });
-      state.designMode = DESIGN_SURVEY_MODE.LANGUAGES;
-    },
-    setDesignModeToTheme(state) {
-      designState.caseReducers.resetSetup(state);
-      designState.caseReducers.setup(state, { payload: themeSetup });
-      state.designMode = DESIGN_SURVEY_MODE.THEME;
-    },
-    changeAttribute: (state, action) => {
-      let payload = action.payload;
-      if (
-        action.payload.key == "content" ||
-        action.payload.key == "instructionList" ||
-        action.payload.key == "relevance" ||
-        action.payload.key == "resources"
-      ) {
-        throw "We are changing attributes way too much than we should";
-      }
-      if (!state[payload.code]) {
-        state[payload.code] = {};
-      }
-      const originalValue = state[payload.code][payload.key];
-
-      state[payload.code][payload.key] = payload.value;
-      if (action.payload.key == "maxChars") {
-        cleanupValidation(state, payload.code);
-      } else if (action.payload.key == "dateFormat") {
-        addMaskedValuesInstructions(payload.code, state[payload.code], state);
-      } else if (action.payload.key == "fullDayFormat") {
-        addMaskedValuesInstructions(payload.code, state[payload.code], state);
-      } else if (action.payload.key == "decimal_separator") {
-        addMaskedValuesInstructions(payload.code, state[payload.code], state);
-      } else if (
-        [
-          "randomize_questions",
-          "randomize_groups",
-          "randomize_options",
-          "randomize_rows",
-          "randomize_columns",
-        ].indexOf(action.payload.key) > -1
-      ) {
-        updateRandomByRule(
-          state[payload.code],
-          action.payload.key,
-          !originalValue || originalValue == "NONE"
-        );
-      }
-    },
-    changeRelevance: (state, action) => {
-      let payload = action.payload;
-      state[payload.code].relevance = payload.value;
-      addRelevanceInstructions(state, payload.code, payload.value);
-    },
-    clearRelevanceConfig: (state, action) => {
-      delete state[action.payload.code].relevance;
-    },
-    setDefaultValue: (state, action) => {
-      const { code, selectedValue } = action.payload;
-      const component = state[code];
-      const valueInstruction = component.instructionList?.find(
-        (instruction) => instruction.code == "value"
-      );
-      if (valueInstruction) {
-        changeInstruction(component, {
-          ...valueInstruction,
-          text: selectedValue,
-          isActive: false,
+        handleChangeContent(state, {
+          payload: {
+            code: nextAnswer.qualifiedCode,
+            key: "label",
+            value: item,
+            lang: state.langInfo.lang,
+          },
         });
-      }
-    },
-    cloneQuestion: (state, action) => {
-      const code = action.payload;
-      const survey = state.Survey;
-      const group = survey.children
-        ?.map((group) => state[group.code])
-        ?.filter(
-          (group) =>
-            group.children &&
-            group.children.findIndex((child) => child.code == code) !== -1
-        )?.[0];
-      if (!group) {
-        return;
-      }
-      const newQuestionId = "Q" + nextQuestionId(state, survey.children);
-      const questionChild = group.children.find((el) => el.code == code);
-      const newQuestion = {
-        type: questionChild.type,
-        code: newQuestionId,
-        qualifiedCode: newQuestionId,
-      };
-      creatNewState(state, state[code], newQuestionId, code, newQuestionId);
-      group.children.splice(
-        group.children.indexOf(questionChild) + 1,
-        0,
-        newQuestion
-      );
-      designState.caseReducers.setup(state, {
-        payload: { code: newQuestionId, rules: setupOptions(newQuestion.type) },
-      });
-      cleanupRandomRules(group);
-      state.index = buildCodeIndex(state);
-      state.focus = newQuestionId;
-    },
-    removeAnswer: (state, action) => {
-      const answerQualifiedCode = action.payload;
-      const codes = splitQuestionCodes(answerQualifiedCode);
-      let question = state[codes[0]];
-      question.children = question.children.filter(
-        (el) => el.code !== codes[1]
-      );
-      delete state[answerQualifiedCode];
-      // could be otherText
-      if (state.setup?.code?.includes(answerQualifiedCode)) {
-        designState.caseReducers.resetSetup(state);
-      }
-      state.index = buildCodeIndex(state);
-      question.designErrors = questionDesignError(question);
-      cleanupValidation(state, codes[0]);
-      cleanupDefaultValue(question);
-      refreshEnumForSingleChoice(question, state);
-      refreshListForMultipleChoice(question, state);
-      addMaskedValuesInstructions(codes[0], question, state);
-      cleanupRandomRules(question);
-      addSkipInstructions(state, codes[0]);
-    },
-    addNewAnswers: (state, action) => {
-      const questionCode = action.payload.questionCode;
-      const data = action.payload.data;
-      const type = action.payload.type;
-      let index = action.payload.index;
-      const question = state[questionCode];
-      const children =
-        question.children?.filter(
-          (it) => state[it.qualifiedCode].type == type
-        ) || [];
-      data.forEach((item, itemIndex) => {
-        if (item) {
-          const nextAnswer = children[index + 1];
-          if (
-            nextAnswer &&
-            nextAnswer.qualifiedCode &&
-            state[nextAnswer.qualifiedCode] &&
-            (!state[nextAnswer.qualifiedCode].content ||
-              !state[nextAnswer.qualifiedCode].content[state.langInfo.lang])
-          ) {
-            designState.caseReducers.changeContent(state, {
-              payload: {
-                code: nextAnswer.qualifiedCode,
-                key: "label",
-                value: item,
-                lang: state.langInfo.lang,
-              },
-            });
-          } else {
-            designState.caseReducers.addNewAnswer(state, {
-              payload: {
-                questionCode,
-                label: item,
-                type,
-                index,
-                focus: itemIndex == data.length - 1,
-              },
-            });
-          }
-
-          index++;
-        }
-      });
-    },
-    onNewLine: (state, action) => {
-      const questionCode = action.payload.questionCode;
-      const index = action.payload.index;
-      const type = action.payload.type;
-      const answers = state[questionCode].children || [];
-      const nextAnswerOfSameType = answers.filter(
-        (answer) => answer.type == type
-      )[index + 1];
-      if (nextAnswerOfSameType && nextAnswerOfSameType.qualifiedCode) {
-        state.focus = nextAnswerOfSameType.qualifiedCode;
       } else {
-        designState.caseReducers.addNewAnswer(state, {
+        handleAddNewAnswer(state, {
           payload: {
             questionCode,
+            label: item,
             type,
             index,
+            focus: itemIndex == data.length - 1,
           },
         });
       }
-    },
-    addNewAnswer: (state, action) => {
-      const questionCode = action.payload.questionCode;
-      const type = action.payload.type;
-      const index = action.payload.index;
-      const focus = action.payload.focus || true;
-      let label = action.payload.label;
-      const answers = state[questionCode].children || [];
-      let nextAnswerIndex = 1;
-      let code = "";
-      let qualifiedCode = "";
-      switch (type) {
-        case "column":
-          nextAnswerIndex = nextId(
-            answers.filter((el) => el.type === "column")
-          );
 
-          code = "Ac" + nextAnswerIndex;
-          qualifiedCode = questionCode + code;
-          addAnswer(state, { code, qualifiedCode, type, label, index });
-          break;
-        case "row":
-          nextAnswerIndex = nextId(answers.filter((el) => el.type === "row"));
-          code = "A" + nextAnswerIndex;
-          qualifiedCode = questionCode + code;
+      index++;
+    }
+  });
+};
 
-          addAnswer(state, {
-            code,
-            qualifiedCode,
-            type,
-            label,
-            index,
-            focus,
-          });
-          break;
-        case "other":
-          code = "Aother";
-          label = "Other";
-          qualifiedCode = questionCode + code;
-          addAnswer(state, {
-            code,
-            qualifiedCode,
-            type,
-            label,
-            index,
-            focus,
-          });
-          addAnswer(state, {
-            code: "Atext",
-            qualifiedCode: qualifiedCode + "Atext",
-            type: "other_text",
-            index,
-          });
-          break;
+export const handleOnNewLine = (state, action) => {
+  const questionCode = action.payload.questionCode;
+  const index = action.payload.index;
+  const type = action.payload.type;
+  const answers = state[questionCode].children || [];
+  const nextAnswerOfSameType = answers.filter(
+    (answer) => answer.type == type
+  )[index + 1];
+  if (nextAnswerOfSameType && nextAnswerOfSameType.qualifiedCode) {
+    state.focus = nextAnswerOfSameType.qualifiedCode;
+  } else {
+    handleAddNewAnswer(state, {
+      payload: {
+        questionCode,
+        type,
+        index,
+      },
+    });
+  }
+};
 
-        case "all":
-          code = "Aall";
-          label = "All of the above";
-          qualifiedCode = questionCode + code;
-          addAnswer(state, {
-            code,
-            qualifiedCode,
-            type,
-            label,
-            index,
-            focus,
-          });
-          break;
-
-        case "none":
-          code = "Anone";
-          label = "None of the above";
-          qualifiedCode = questionCode + code;
-          addAnswer(state, {
-            code,
-            qualifiedCode,
-            type,
-            label,
-            index,
-            focus,
-          });
-          break;
-        default:
-          nextAnswerIndex = nextId(answers);
-          code = "A" + nextAnswerIndex;
-          qualifiedCode = questionCode + code;
-          addAnswer(state, {
-            code,
-            qualifiedCode,
-            label,
-            index,
-            focus,
-          });
-          break;
-      }
-    },
-
-    deleteGroup: (state, action) => {
-      const groupCode = action.payload;
-      if (state.setup?.code == groupCode) {
-        designState.caseReducers.resetSetup(state);
-      }
-      if (state[groupCode].groupType == "END") {
-        state.error = {
-          message: "There must always be an end group. for an end message ",
-        };
-        return;
-      }
-      const survey = state.Survey;
-      const index = survey.children?.findIndex((x) => x.code === groupCode);
-      survey.children.splice(index, 1);
-      delete state[groupCode];
-      cleanupRandomRules(survey);
-      cleanupSkipDestinations(state, groupCode);
-    },
-    deleteQuestion: (state, action) => {
-      const questionCode = action.payload;
-      if (state.setup?.code == questionCode) {
-        designState.caseReducers.resetSetup(state);
-      }
-      const survey = state.Survey;
-      const group = survey.children
-        ?.map((group) => state[group.code])
-        ?.filter(
-          (group) =>
-            group.children &&
-            group.children.findIndex((child) => child.code == questionCode) !==
-              -1
-        )?.[0];
-      if (!group) {
-        return;
-      }
-      const questionIndex = group.children.findIndex(
-        (x) => x.code === questionCode
+export const handleAddNewAnswer = (state, action) => {
+  const questionCode = action.payload.questionCode;
+  const type = action.payload.type;
+  const index = action.payload.index;
+  const focus = action.payload.focus || true;
+  let label = action.payload.label;
+  const answers = state[questionCode].children || [];
+  let nextAnswerIndex = 1;
+  let code = "";
+  let qualifiedCode = "";
+  switch (type) {
+    case "column":
+      nextAnswerIndex = nextId(
+        answers.filter((el) => el.type === "column")
       );
-      let children = [...group.children];
-      if (children.length === 1) {
-        group.children = [];
-      } else {
-        group.children.splice(questionIndex, 1);
-      }
-      delete state[questionCode];
-      cleanupRandomRules(group);
-      cleanupSkipDestinations(state, questionCode);
-    },
-    changeContent: (state, action) => {
-      let payload = action.payload;
-      if (!state[payload.code].content) {
-        state[payload.code].content = {};
-        state[payload.code].content[payload.lang] = {};
-      } else if (!state[payload.code].content[payload.lang]) {
-        state[payload.code].content[payload.lang] = {};
-      }
-      const prefixToRemove = `format_${payload.key}_${payload.lang}`;
-      const toRemove = state[payload.code].instructionList?.filter(
-        (instruction) => instruction.code.startsWith(prefixToRemove)
-      );
-      toRemove?.forEach((instruction) => {
-        console.log(instruction.code);
-        changeInstruction(state[payload.code], {
-          code: instruction.code,
-          remove: true,
-        });
+
+      code = "Ac" + nextAnswerIndex;
+      qualifiedCode = questionCode + code;
+      addAnswer(state, { code, qualifiedCode, type, label, index });
+      break;
+    case "row":
+      nextAnswerIndex = nextId(answers.filter((el) => el.type === "row"));
+      code = "A" + nextAnswerIndex;
+      qualifiedCode = questionCode + code;
+
+      addAnswer(state, {
+        code,
+        qualifiedCode,
+        type,
+        label,
+        index,
+        focus,
       });
-
-      state[payload.code].instructionList = state[
-        payload.code
-      ].instructionList?.filter(
-        (instruction) => !instruction.code.startsWith(prefixToRemove)
-      );
-      const referenceInstructions = buildReferenceInstruction(
-        payload.value,
-        payload.key,
-        payload.lang,
-        [payload.value, payload.key, payload.lang]
-      );
-      referenceInstructions?.forEach((instruction) =>
-        changeInstruction(state[payload.code], instruction)
-      );
-
-      saveContentResources(
-        state[payload.code],
-        payload.value,
-        payload.lang,
-        payload.key
-      );
-
-      state[payload.code].content[payload.lang][payload.key] = payload.value;
-    },
-    changeCustomCss: (state, action) => {
-      let payload = action.payload;
-      const referenceInstructions = buildReferenceInstruction(
-        payload.value,
-        "custom",
-        "css",
-        ["customCss"]
-      );
-      state[payload.code].customCss = payload.value
-      referenceInstructions?.forEach((instruction) =>
-        changeInstruction(state[payload.code], instruction)
-      );
-    },
-    changeResources: (state, action) => {
-      let payload = action.payload;
-      if (!state[payload.code].resources) {
-        state[payload.code].resources = {};
-      }
-      state[payload.code].resources[payload.key] = payload.value;
-    },
-    updateRandom: (state, action) => {
-      const payload = action.payload;
-      const componentState = state[payload.code];
-      if (payload.groups) {
-        const instruction = { code: "random_group", groups: payload.groups };
-        changeInstruction(componentState, instruction);
-      } else {
-        removeInstruction(componentState, "random_group");
-      }
-    },
-    updateRandomByType: (state, action) => {
-      const payload = action.payload;
-      const componentState = state[payload.code];
-      const otherChildrenCodes = state[payload.code]?.children
-        ?.filter((el) => el.type !== payload.type)
-        ?.map((el) => el.code);
-      const randomInstruction = instructionByCode(
-        componentState,
-        "random_group"
-      );
-      const otherRandomOrders =
-        randomInstruction?.groups?.filter(
-          (x) => x.length && x.some((elem) => otherChildrenCodes.includes(elem))
-        ) || [];
-      const groups = payload.groups.concat(otherRandomOrders);
-      if (groups) {
-        const instruction = { code: "random_group", groups };
-        changeInstruction(componentState, instruction);
-      } else {
-        removeInstruction(componentState, "random_group");
-      }
-    },
-
-    // === SKIP LOGIC REDUCERS ===
-    addSkipRule: (state, action) => {
-      const { code } = action.payload;
-      if (!state[code].skip_logic) {
-        state[code].skip_logic = [];
-      }
-      state[code].skip_logic.push({ condition: [], skipTo: null });
-    },
-    updateSkipRule: (state, action) => {
-      const { code, ruleIndex, updates } = action.payload;
-      const rule = state[code].skip_logic[ruleIndex];
-      Object.assign(rule, updates);
-      // Reset toEnd/disqualify if destination is not a group
-      if (updates.skipTo && !updates.skipTo.startsWith("G")) {
-        rule.toEnd = false;
-        rule.disqualify = false;
-      }
-      addSkipInstructions(state, code);
-    },
-    removeSkipRule: (state, action) => {
-      const { code, ruleIndex } = action.payload;
-      state[code].skip_logic.splice(ruleIndex, 1);
-      addSkipInstructions(state, code);
-    },
-
-    addCustomValidationRule: (state, action) => {
-      const { code } = action.payload;
-
-      const numbers = (state[code].instructionList || [])
-        .map((i) => i.code.match(/^validation_custom_(\d+)$/)?.[1])
-        .filter(Boolean)
-        .map(Number);
-
-      const newRuleCode = `validation_custom_${Math.max(0, ...numbers) + 1}`;
-
-      changeInstruction(state[code], {
-        code: newRuleCode,
-        text: "",
-        returnType: "boolean",
-        isActive: true,
+      break;
+    case "other":
+      code = "Aother";
+      label = "Other";
+      qualifiedCode = questionCode + code;
+      addAnswer(state, {
+        code,
+        qualifiedCode,
+        type,
+        label,
+        index,
+        focus,
       });
-    },
-
-    updateCustomValidationRuleText: (state, action) => {
-      const { code, ruleCode, text } = action.payload;
-      state[code].instructionList.find((i) => i.code === ruleCode).text = text;
-    },
-
-    renameCustomValidationRule: (state, action) => {
-      const { code, ruleCode, newCode } = action.payload;
-      const instruction = state[code].instructionList.find(
-        (i) => i.code === ruleCode
-      );
-      instruction.code = newCode;
-      const content = state[code].content || {};
-      Object.keys(content).forEach((lang) => {
-        if (content[lang][ruleCode] !== undefined) {
-          content[lang][newCode] = content[lang][ruleCode];
-          delete content[lang][ruleCode];
-        }
+      addAnswer(state, {
+        code: "Atext",
+        qualifiedCode: qualifiedCode + "Atext",
+        type: "other_text",
+        index,
       });
-    },
+      break;
 
-    updateCustomValidationRuleError: (state, action) => {
-      const { code, ruleCode, lang, value } = action.payload;
-      if (value) {
-        state[code].content[lang][ruleCode] = value;
-      } else {
-        delete state[code].content[lang][ruleCode];
-      }
-    },
-
-    removeCustomValidationRule: (state, action) => {
-      const { code, ruleCode } = action.payload;
-
-      changeInstruction(state[code], { code: ruleCode, remove: true });
-
-      const content = state[code].content || {};
-      Object.keys(content).forEach((lang) => {
-        delete content[lang][ruleCode];
+    case "all":
+      code = "Aall";
+      label = "All of the above";
+      qualifiedCode = questionCode + code;
+      addAnswer(state, {
+        code,
+        qualifiedCode,
+        type,
+        label,
+        index,
+        focus,
       });
-    },
+      break;
 
-    updateInstruction: (state, action) => {
-      const { code, instruction } = action.payload;
+    case "none":
+      code = "Anone";
+      label = "None of the above";
+      qualifiedCode = questionCode + code;
+      addAnswer(state, {
+        code,
+        qualifiedCode,
+        type,
+        label,
+        index,
+        focus,
+      });
+      break;
+    default:
+      nextAnswerIndex = nextId(answers);
+      code = "A" + nextAnswerIndex;
+      qualifiedCode = questionCode + code;
+      addAnswer(state, {
+        code,
+        qualifiedCode,
+        label,
+        index,
+        focus,
+      });
+      break;
+  }
+};
 
-      if (!state[code]) {
-        return;
-      }
+export const handleDeleteGroup = (state, action) => {
+  const groupCode = action.payload;
+  if (state.setup?.code == groupCode) {
+    handleResetSetup(state);
+  }
+  if (state[groupCode].groupType == "END") {
+    state.error = {
+      message: "There must always be an end group. for an end message ",
+    };
+    return;
+  }
+  const survey = state.Survey;
+  const index = survey.children?.findIndex((x) => x.code === groupCode);
+  survey.children.splice(index, 1);
+  delete state[groupCode];
+  cleanupRandomRules(survey);
+  cleanupSkipDestinations(state, groupCode);
+};
 
-      changeInstruction(state[code], instruction);
-    },
+export const handleDeleteQuestion = (state, action) => {
+  const questionCode = action.payload;
+  if (state.setup?.code == questionCode) {
+    handleResetSetup(state);
+  }
+  const survey = state.Survey;
+  const group = survey.children
+    ?.map((group) => state[group.code])
+    ?.filter(
+      (group) =>
+        group.children &&
+        group.children.findIndex((child) => child.code == questionCode) !==
+          -1
+    )?.[0];
+  if (!group) {
+    return;
+  }
+  const questionIndex = group.children.findIndex(
+    (x) => x.code === questionCode
+  );
+  let children = [...group.children];
+  if (children.length === 1) {
+    group.children = [];
+  } else {
+    group.children.splice(questionIndex, 1);
+  }
+  delete state[questionCode];
+  cleanupRandomRules(group);
+  cleanupSkipDestinations(state, questionCode);
+};
 
-    onBaseLangChanged: (state, action) => {
-      state.langInfo.mainLang = action.payload.code;
-      state.Survey.defaultLang = action.payload;
-      state.Survey.additionalLang = state.Survey.additionalLang?.filter(
-        (language) => language.code !== action.payload.code
-      );
-      state.langInfo.lang = action.payload.code;
-      state.langInfo.onMainLang = true;
-      state.langInfo.languagesList = [action.payload].concat(
-        state.Survey.additionalLang || []
-      );
-    },
-    onAdditionalLangAdded: (state, action) => {
-      state.Survey.additionalLang = (state.Survey.additionalLang || []).concat(
-        action.payload
-      );
-      state.langInfo.languagesList = [state.Survey.defaultLang].concat(
-        state.Survey.additionalLang || []
-      );
-    },
-    onAdditionalLangRemoved: (state, action) => {
-      state.Survey.additionalLang = state.Survey.additionalLang.filter(
-        (language) => language.code !== action.payload.code
-      );
-      state.langInfo.languagesList = [state.Survey.defaultLang].concat(
-        state.Survey.additionalLang || []
-      );
-    },
-    changeLang: (state, action) => {
-      state.langInfo.lang = action.payload;
-      state.langInfo.onMainLang =
-        state.langInfo.lang == state.langInfo.mainLang;
-    },
-    resetFocus: (state, action) => {
-      state.focus = null;
-    },
-    setSaving: (state, action) => {
-      state.isSaving = action.payload;
-    },
-    setUpdating: (state, action) => {
-      state.isUpdating = action.payload;
-    },
-    onDrag: (state, action) => {
-      state.skipScroll = true;
+export const handleChangeContent = (state, action) => {
+  let payload = action.payload;
+  if (!state[payload.code].content) {
+    state[payload.code].content = {};
+    state[payload.code].content[payload.lang] = {};
+  } else if (!state[payload.code].content[payload.lang]) {
+    state[payload.code].content[payload.lang] = {};
+  }
+  const prefixToRemove = `format_${payload.key}_${payload.lang}`;
+  const toRemove = state[payload.code].instructionList?.filter(
+    (instruction) => instruction.code.startsWith(prefixToRemove)
+  );
+  toRemove?.forEach((instruction) => {
+    console.log(instruction.code);
+    changeInstruction(state[payload.code], {
+      code: instruction.code,
+      remove: true,
+    });
+  });
 
-      const payload = action.payload;
-      switch (payload.type) {
-        case "reorder_questions":
-          reorderQuestions(state, state.Survey, payload);
-          state.index = buildCodeIndex(state);
-          break;
-        case "reparent_question":
-          reparentQuestion(state, state.Survey, payload);
-          state.index = buildCodeIndex(state);
-          break;
-        case "reorder_groups":
-          reorderGroups(state.Survey, payload);
-          state.index = buildCodeIndex(state);
-          break;
-        case "reorder_answers":
-          reorderAnswers(state, payload);
-          break;
-        case "reorder_answers_by_type":
-          reorderAnswersByType(state, payload);
-          break;
-        case "new_question":
-          newQuestion(state, payload);
-          state.index = buildCodeIndex(state);
-          break;
-        case "new_group":
-          if (payload.groupType == "group") {
-            newGroup(state, payload);
-            state.index = buildCodeIndex(state);
-          } else if (
-            payload.groupType == "end" ||
-            payload.groupType == "welcome"
-          ) {
-            specialGroup(state, payload);
-          }
-          break;
-          // do nothing
-          deafult: break;
-      }
-    },
-    addComponent: (state, action) => {
-      const { type, questionType } = action.payload;
-      const survey = state.Survey;
-      state.skipScroll = false;
+  state[payload.code].instructionList = state[
+    payload.code
+  ].instructionList?.filter(
+    (instruction) => !instruction.code.startsWith(prefixToRemove)
+  );
+  const referenceInstructions = buildReferenceInstruction(
+    payload.value,
+    payload.key,
+    payload.lang,
+    [payload.value, payload.key, payload.lang]
+  );
+  referenceInstructions?.forEach((instruction) =>
+    changeInstruction(state[payload.code], instruction)
+  );
 
-      if (type === "group") {
-        const lastGroupIndex = Math.max(0, survey.children.length - 1);
-        newGroup(state, { toIndex: lastGroupIndex });
-      } else if (type === "question") {
-        if (state.Survey.children.length == 1) {
-          newGroup(state, { toIndex: 0 });
-        }
-        const lastGroupIndex = Math.max(0, survey.children.length - 2);
-        const destinationGroupCode = survey.children[lastGroupIndex].code;
-        const destinationGroup = state[destinationGroupCode];
-        const toIndex = destinationGroup.children?.length || 0;
-        newQuestion(state, {
-          destination: destinationGroupCode,
-          questionType,
-          toIndex,
-        });
-      }
+  saveContentResources(
+    state[payload.code],
+    payload.value,
+    payload.lang,
+    payload.key
+  );
+
+  state[payload.code].content[payload.lang][payload.key] = payload.value;
+};
+
+export const handleChangeCustomCss = (state, action) => {
+  let payload = action.payload;
+  const referenceInstructions = buildReferenceInstruction(
+    payload.value,
+    "custom",
+    "css",
+    ["customCss"]
+  );
+  state[payload.code].customCss = payload.value
+  referenceInstructions?.forEach((instruction) =>
+    changeInstruction(state[payload.code], instruction)
+  );
+};
+
+export const handleChangeResources = (state, action) => {
+  let payload = action.payload;
+  if (!state[payload.code].resources) {
+    state[payload.code].resources = {};
+  }
+  state[payload.code].resources[payload.key] = payload.value;
+};
+
+export const handleUpdateRandom = (state, action) => {
+  const payload = action.payload;
+  const componentState = state[payload.code];
+  if (payload.groups) {
+    const instruction = { code: "random_group", groups: payload.groups };
+    changeInstruction(componentState, instruction);
+  } else {
+    removeInstruction(componentState, "random_group");
+  }
+};
+
+export const handleUpdateRandomByType = (state, action) => {
+  const payload = action.payload;
+  const componentState = state[payload.code];
+  const otherChildrenCodes = state[payload.code]?.children
+    ?.filter((el) => el.type !== payload.type)
+    ?.map((el) => el.code);
+  const randomInstruction = instructionByCode(
+    componentState,
+    "random_group"
+  );
+  const otherRandomOrders =
+    randomInstruction?.groups?.filter(
+      (x) => x.length && x.some((elem) => otherChildrenCodes.includes(elem))
+    ) || [];
+  const groups = payload.groups.concat(otherRandomOrders);
+  if (groups) {
+    const instruction = { code: "random_group", groups };
+    changeInstruction(componentState, instruction);
+  } else {
+    removeInstruction(componentState, "random_group");
+  }
+};
+
+export const handleAddSkipRule = (state, action) => {
+  const { code } = action.payload;
+  if (!state[code].skip_logic) {
+    state[code].skip_logic = [];
+  }
+  state[code].skip_logic.push({ condition: [], skipTo: null });
+};
+
+export const handleUpdateSkipRule = (state, action) => {
+  const { code, ruleIndex, updates } = action.payload;
+  const rule = state[code].skip_logic[ruleIndex];
+  Object.assign(rule, updates);
+  // Reset toEnd/disqualify if destination is not a group
+  if (updates.skipTo && !updates.skipTo.startsWith("G")) {
+    rule.toEnd = false;
+    rule.disqualify = false;
+  }
+  addSkipInstructions(state, code);
+};
+
+export const handleRemoveSkipRule = (state, action) => {
+  const { code, ruleIndex } = action.payload;
+  state[code].skip_logic.splice(ruleIndex, 1);
+  addSkipInstructions(state, code);
+};
+
+export const handleAddCustomValidationRule = (state, action) => {
+  const { code } = action.payload;
+
+  const numbers = (state[code].instructionList || [])
+    .map((i) => i.code.match(/^validation_custom_(\d+)$/)?.[1])
+    .filter(Boolean)
+    .map(Number);
+
+  const newRuleCode = `validation_custom_${Math.max(0, ...numbers) + 1}`;
+
+  changeInstruction(state[code], {
+    code: newRuleCode,
+    text: "",
+    returnType: "boolean",
+    isActive: true,
+  });
+};
+
+export const handleUpdateCustomValidationRuleText = (state, action) => {
+  const { code, ruleCode, text } = action.payload;
+  state[code].instructionList.find((i) => i.code === ruleCode).text = text;
+};
+
+export const handleRenameCustomValidationRule = (state, action) => {
+  const { code, ruleCode, newCode } = action.payload;
+  const instruction = state[code].instructionList.find(
+    (i) => i.code === ruleCode
+  );
+  instruction.code = newCode;
+  const content = state[code].content || {};
+  Object.keys(content).forEach((lang) => {
+    if (content[lang][ruleCode] !== undefined) {
+      content[lang][newCode] = content[lang][ruleCode];
+      delete content[lang][ruleCode];
+    }
+  });
+};
+
+export const handleUpdateCustomValidationRuleError = (state, action) => {
+  const { code, ruleCode, lang, value } = action.payload;
+  if (value) {
+    state[code].content[lang][ruleCode] = value;
+  } else {
+    delete state[code].content[lang][ruleCode];
+  }
+};
+
+export const handleRemoveCustomValidationRule = (state, action) => {
+  const { code, ruleCode } = action.payload;
+
+  changeInstruction(state[code], { code: ruleCode, remove: true });
+
+  const content = state[code].content || {};
+  Object.keys(content).forEach((lang) => {
+    delete content[lang][ruleCode];
+  });
+};
+
+export const handleUpdateInstruction = (state, action) => {
+  const { code, instruction } = action.payload;
+
+  if (!state[code]) {
+    return;
+  }
+
+  changeInstruction(state[code], instruction);
+};
+
+export const handleOnBaseLangChanged = (state, action) => {
+  state.langInfo.mainLang = action.payload.code;
+  state.Survey.defaultLang = action.payload;
+  state.Survey.additionalLang = state.Survey.additionalLang?.filter(
+    (language) => language.code !== action.payload.code
+  );
+  state.langInfo.lang = action.payload.code;
+  state.langInfo.onMainLang = true;
+  state.langInfo.languagesList = [action.payload].concat(
+    state.Survey.additionalLang || []
+  );
+};
+
+export const handleOnAdditionalLangAdded = (state, action) => {
+  state.Survey.additionalLang = (state.Survey.additionalLang || []).concat(
+    action.payload
+  );
+  state.langInfo.languagesList = [state.Survey.defaultLang].concat(
+    state.Survey.additionalLang || []
+  );
+};
+
+export const handleOnAdditionalLangRemoved = (state, action) => {
+  state.Survey.additionalLang = state.Survey.additionalLang.filter(
+    (language) => language.code !== action.payload.code
+  );
+  state.langInfo.languagesList = [state.Survey.defaultLang].concat(
+    state.Survey.additionalLang || []
+  );
+};
+
+export const handleOnDrag = (state, action) => {
+  state.skipScroll = true;
+
+  const payload = action.payload;
+  switch (payload.type) {
+    case "reorder_questions":
+      reorderQuestions(state, state.Survey, payload);
       state.index = buildCodeIndex(state);
-    },
-  },
-});
+      break;
+    case "reparent_question":
+      reparentQuestion(state, state.Survey, payload);
+      state.index = buildCodeIndex(state);
+      break;
+    case "reorder_groups":
+      reorderGroups(state.Survey, payload);
+      state.index = buildCodeIndex(state);
+      break;
+    case "reorder_answers":
+      reorderAnswers(state, payload);
+      break;
+    case "reorder_answers_by_type":
+      reorderAnswersByType(state, payload);
+      break;
+    case "new_question":
+      newQuestion(state, payload);
+      state.index = buildCodeIndex(state);
+      break;
+    case "new_group":
+      if (payload.groupType == "group") {
+        newGroup(state, payload);
+        state.index = buildCodeIndex(state);
+      } else if (
+        payload.groupType == "end" ||
+        payload.groupType == "welcome"
+      ) {
+        specialGroup(state, payload);
+      }
+      break;
+      // do nothing
+      deafult: break;
+  }
+};
 
-export const {
-  newVersionReceived,
-  designStateReceived,
-  onBaseLangChanged,
-  onAdditionalLangAdded,
-  onAdditionalLangRemoved,
-  changeLang,
-  changeCustomCss,
-  changeAttribute,
-  changeTimeFormats,
-  changeContent,
-  changeResources,
-  deleteQuestion,
-  cloneQuestion,
-  deleteGroup,
-  onNewLine,
-  resetFocus,
-  addNewAnswer,
-  addNewAnswers,
-  setDesignModeToDesign,
-  setDesignModeToLang,
-  setDesignModeToTheme,
-  removeAnswer,
-  setup,
-  resetSetup,
-  changeValidationValue,
-  updateRandom,
-  updateRandomByType,
-  addSkipRule,
-  updateSkipRule,
-  removeSkipRule,
-  addCustomValidationRule,
-  updateCustomValidationRuleText,
-  renameCustomValidationRule,
-  updateCustomValidationRuleError,
-  removeCustomValidationRule,
-  updateInstruction,
-  changeRelevance,
-  clearRelevanceConfig,
-  setDefaultValue,
-  onDrag,
-  addComponent,
-  setSaving,
-  setUpdating,
-} = designState.actions;
+export const handleAddComponent = (state, action) => {
+  const { type, questionType } = action.payload;
+  const survey = state.Survey;
+  state.skipScroll = false;
 
-export default designState.reducer;
+  if (type === "group") {
+    const lastGroupIndex = Math.max(0, survey.children.length - 1);
+    newGroup(state, { toIndex: lastGroupIndex });
+  } else if (type === "question") {
+    if (state.Survey.children.length == 1) {
+      newGroup(state, { toIndex: 0 });
+    }
+    const lastGroupIndex = Math.max(0, survey.children.length - 2);
+    const destinationGroupCode = survey.children[lastGroupIndex].code;
+    const destinationGroup = state[destinationGroupCode];
+    const toIndex = destinationGroup.children?.length || 0;
+    newQuestion(state, {
+      destination: destinationGroupCode,
+      questionType,
+      toIndex,
+    });
+  }
+  state.index = buildCodeIndex(state);
+};
 
-const cleanupRandomRules = (componentState) => {
+// --- Helper functions ---
+
+export const cleanupRandomRules = (componentState) => {
   if (componentState["randomize_questions"]) {
     updateRandomByRule(componentState, "randomize_questions");
   } else if (componentState["randomize_groups"]) {
@@ -854,7 +808,7 @@ const cleanupRandomRules = (componentState) => {
 };
 
 // Clean up skip_logic rules that point to a deleted destination
-const cleanupSkipDestinations = (state, deletedCode) => {
+export const cleanupSkipDestinations = (state, deletedCode) => {
   Object.keys(state).forEach((key) => {
     const component = state[key];
     if (Array.isArray(component?.skip_logic)) {
@@ -871,7 +825,7 @@ const cleanupSkipDestinations = (state, deletedCode) => {
   });
 };
 
-const saveContentResources = (
+export const saveContentResources = (
   component,
   contentValue,
   contentLang,
@@ -898,7 +852,7 @@ const saveContentResources = (
   });
 };
 
-const reparentQuestion = (state, survey, payload) => {
+export const reparentQuestion = (state, survey, payload) => {
   let index = buildIndex(state);
   const sourceGroup = state[payload.source];
   const destinationGroup = state[payload.destination];
@@ -924,7 +878,7 @@ const reparentQuestion = (state, survey, payload) => {
   cleanupRandomRules(sourceGroup);
 };
 
-const reorderQuestions = (state, survey, payload) => {
+export const reorderQuestions = (state, survey, payload) => {
   const sourceGroup = state[payload.source];
   const destinationGroup = state[payload.destination];
   const sourceQuestionIndex = sourceGroup.children.findIndex(
@@ -943,7 +897,7 @@ const reorderQuestions = (state, survey, payload) => {
   cleanupRandomRules(sourceGroup);
 };
 
-const newQuestion = (state, payload) => {
+export const newQuestion = (state, payload) => {
   const survey = state.Survey;
   let questionId = nextQuestionId(state, survey.children);
   const questionObject = createQuestion(
@@ -993,7 +947,7 @@ const newQuestion = (state, payload) => {
   };
   cleanupRandomRules(destinationGroup);
   state.focus = newCode;
-  designState.caseReducers.setup(state, {
+  handleSetup(state, {
     payload: {
       code: newCode,
       rules: setupOptions(payload.questionType),
@@ -1001,7 +955,7 @@ const newQuestion = (state, payload) => {
   });
 };
 
-const newGroup = (state, payload) => {
+export const newGroup = (state, payload) => {
   const survey = state.Survey;
   const group = createGroup("GROUP", nextGroupId(survey.children));
   if (!survey.children) {
@@ -1023,7 +977,7 @@ const newGroup = (state, payload) => {
   };
   cleanupRandomRules(survey);
   state.focus = group.newGroup.code;
-  designState.caseReducers.setup(state, {
+  handleSetup(state, {
     payload: {
       code: group.newGroup.code,
       rules: setupOptions(group.newGroup.type),
@@ -1031,7 +985,7 @@ const newGroup = (state, payload) => {
   });
 };
 
-const specialGroup = (state, payload) => {
+export const specialGroup = (state, payload) => {
   const survey = state.Survey;
   if (!survey.children) {
     survey.children = [];
@@ -1051,7 +1005,7 @@ const specialGroup = (state, payload) => {
     const group = createGroup("WELCOME", nextGroupId(survey.children));
     survey.children.splice(0, 0, group.newGroup);
     state[group.newGroup.code] = group.state;
-    designState.caseReducers.setup(state, {
+    handleSetup(state, {
       payload: {
         code: group.newGroup.code,
         rules: setupOptions(group.newGroup.type),
@@ -1061,7 +1015,7 @@ const specialGroup = (state, payload) => {
     const group = createGroup("END", nextGroupId(survey.children));
     survey.children.push(group.newGroup);
     state[group.newGroup.code] = group.state;
-    designState.caseReducers.setup(state, {
+    handleSetup(state, {
       payload: {
         code: group.newGroup.code,
         rules: setupOptions(group.newGroup.type),
@@ -1070,7 +1024,7 @@ const specialGroup = (state, payload) => {
   }
 };
 
-const addAnswer = (state, answer) => {
+export const addAnswer = (state, answer) => {
   const lang = state.langInfo.mainLang;
   const label = answer.label;
   const qualifiedCode = answer.qualifiedCode;
@@ -1096,14 +1050,14 @@ const addAnswer = (state, answer) => {
   }
 };
 
-const reorderGroups = (survey, payload) => {
+export const reorderGroups = (survey, payload) => {
   survey.children = reorder(
     survey.children,
     payload.fromIndex,
     payload.toIndex
   );
 };
-const reorderAnswers = (state, payload) => {
+export const reorderAnswers = (state, payload) => {
   const codes = splitQuestionCodes(payload.id);
   const parentCode = codes.slice(0, codes.length - 1).join("");
   const component = state[parentCode];
@@ -1113,7 +1067,7 @@ const reorderAnswers = (state, payload) => {
     payload.toIndex
   );
 };
-const reorderAnswersByType = (state, payload) => {
+export const reorderAnswersByType = (state, payload) => {
   const codes = splitQuestionCodes(payload.id);
   const parentCode = codes.slice(0, codes.length - 1).join("");
   const component = state[parentCode];
@@ -1128,7 +1082,7 @@ const reorderAnswersByType = (state, payload) => {
   component.children = reorder(component.children, fromIndex, toIndex);
 };
 
-const insertAnswer = (state, answer, parentCode, index) => {
+export const insertAnswer = (state, answer, parentCode, index) => {
   const component = state[parentCode];
   if (component) {
     if (!component.children) {
@@ -1157,7 +1111,7 @@ const insertAnswer = (state, answer, parentCode, index) => {
     return false;
   }
 };
-const buildIndex = (state) => {
+export const buildIndex = (state) => {
   let retrunRestult = [];
   state.Survey.children?.forEach((group) => {
     retrunRestult.push(group.code);
@@ -1173,7 +1127,7 @@ const buildIndex = (state) => {
   return retrunRestult;
 };
 
-const buildCodeIndex = (state) => {
+export const buildCodeIndex = (state) => {
   let retrunRestult = {};
   let groupCount = 0;
   let questionCount = 0;
@@ -1198,11 +1152,11 @@ const buildCodeIndex = (state) => {
   return retrunRestult;
 };
 
-const splitQuestionCodes = (code) => {
+export const splitQuestionCodes = (code) => {
   return code.split(/(A[a-z_0-9]+|Q[a-z_0-9]+)/).filter(Boolean);
 };
 
-const cleanupValidation = (state, code) => {
+export const cleanupValidation = (state, code) => {
   const component = state[code];
   if (!component.validation) {
     return;
@@ -1211,7 +1165,7 @@ const cleanupValidation = (state, code) => {
   ruleKeys.forEach((key) => processValidation(state, code, key, true));
 };
 
-const addRelevanceInstructions = (state, code, relevance) => {
+export const addRelevanceInstructions = (state, code, relevance) => {
   const instruction = conditionalRelevanceEquation(
     relevance.logic,
     relevance.rule,
@@ -1219,6 +1173,123 @@ const addRelevanceInstructions = (state, code, relevance) => {
   );
   changeInstruction(state[code], instruction);
 };
+
+// --- Slice definition ---
+
+export const designState = createSlice({
+  name: "designState",
+  initialState: { state: {} },
+  reducers: {
+    designStateReceived: handleDesignStateReceived,
+    setup: handleSetup,
+    newVersionReceived(state, action) {
+      state.versionDto = action.payload;
+    },
+    changeValidationValue: handleChangeValidationValue,
+    resetSetup: handleResetSetup,
+    setDesignModeToDesign: handleSetDesignModeToDesign,
+    setDesignModeToLang: handleSetDesignModeToLang,
+    setDesignModeToTheme: handleSetDesignModeToTheme,
+    changeAttribute: handleChangeAttribute,
+    changeRelevance: handleChangeRelevance,
+    clearRelevanceConfig: (state, action) => {
+      delete state[action.payload.code].relevance;
+    },
+    setDefaultValue: handleSetDefaultValue,
+    cloneQuestion: handleCloneQuestion,
+    removeAnswer: handleRemoveAnswer,
+    addNewAnswers: handleAddNewAnswers,
+    onNewLine: handleOnNewLine,
+    addNewAnswer: handleAddNewAnswer,
+    deleteGroup: handleDeleteGroup,
+    deleteQuestion: handleDeleteQuestion,
+    changeContent: handleChangeContent,
+    changeCustomCss: handleChangeCustomCss,
+    changeResources: handleChangeResources,
+    updateRandom: handleUpdateRandom,
+    updateRandomByType: handleUpdateRandomByType,
+    addSkipRule: handleAddSkipRule,
+    updateSkipRule: handleUpdateSkipRule,
+    removeSkipRule: handleRemoveSkipRule,
+    addCustomValidationRule: handleAddCustomValidationRule,
+    updateCustomValidationRuleText: handleUpdateCustomValidationRuleText,
+    renameCustomValidationRule: handleRenameCustomValidationRule,
+    updateCustomValidationRuleError: handleUpdateCustomValidationRuleError,
+    removeCustomValidationRule: handleRemoveCustomValidationRule,
+    updateInstruction: handleUpdateInstruction,
+    onBaseLangChanged: handleOnBaseLangChanged,
+    onAdditionalLangAdded: handleOnAdditionalLangAdded,
+    onAdditionalLangRemoved: handleOnAdditionalLangRemoved,
+    changeLang: (state, action) => {
+      state.langInfo.lang = action.payload;
+      state.langInfo.onMainLang =
+        state.langInfo.lang == state.langInfo.mainLang;
+    },
+    resetFocus: (state) => {
+      state.focus = null;
+    },
+    setSaving: (state, action) => {
+      state.isSaving = action.payload;
+    },
+    setUpdating: (state, action) => {
+      state.isUpdating = action.payload;
+    },
+    onDrag: handleOnDrag,
+    addComponent: handleAddComponent,
+  },
+});
+
+// --- Action exports ---
+
+export const {
+  newVersionReceived,
+  designStateReceived,
+  onBaseLangChanged,
+  onAdditionalLangAdded,
+  onAdditionalLangRemoved,
+  changeLang,
+  changeCustomCss,
+  changeAttribute,
+  changeTimeFormats,
+  changeContent,
+  changeResources,
+  deleteQuestion,
+  cloneQuestion,
+  deleteGroup,
+  onNewLine,
+  resetFocus,
+  addNewAnswer,
+  addNewAnswers,
+  setDesignModeToDesign,
+  setDesignModeToLang,
+  setDesignModeToTheme,
+  removeAnswer,
+  setup,
+  resetSetup,
+  changeValidationValue,
+  updateRandom,
+  updateRandomByType,
+  addSkipRule,
+  updateSkipRule,
+  removeSkipRule,
+  addCustomValidationRule,
+  updateCustomValidationRuleText,
+  renameCustomValidationRule,
+  updateCustomValidationRuleError,
+  removeCustomValidationRule,
+  updateInstruction,
+  changeRelevance,
+  clearRelevanceConfig,
+  setDefaultValue,
+  onDrag,
+  addComponent,
+  setSaving,
+  setUpdating,
+} = designState.actions;
+
+export default designState.reducer;
+
+// --- Other exports ---
 
 export const mapCodeToUserFriendlyOrder = (code, index) => {
   let newCode = cloneDeep(code);
@@ -1247,7 +1318,7 @@ export const mapCodeToUserFriendlyOrder = (code, index) => {
   return newCode;
 };
 
-const creatNewState = (
+export const creatNewState = (
   state,
   toBeCopied,
   newStateCode,

--- a/src/state/design/designState.js
+++ b/src/state/design/designState.js
@@ -1,8 +1,15 @@
 import { createSlice, current } from "@reduxjs/toolkit";
-import { firstIndexInArray, isEquivalent, nextId } from "~/utils/design/utils";
-import { createGroup } from "~/components/design/NewComponentsPanel";
-
-import { lastIndexInArray } from "~/utils/design/utils";
+import {
+  firstIndexInArray,
+  isEquivalent,
+  nextId,
+  lastIndexInArray,
+} from "~/utils/design/pureFunctions";
+import {
+  createGroup,
+  createQuestion,
+  questionDesignError,
+} from "./componentFactories";
 import cloneDeep from "lodash.clonedeep";
 import {
   buildValidationDefaultData,
@@ -12,10 +19,7 @@ import {
   buildReferenceInstruction,
 } from "./stateUtils";
 import { languageSetup, setupOptions, themeSetup } from "~/constants/design";
-import {
-  createQuestion,
-  questionDesignError,
-} from "~/components/Questions/utils";
+import { LANGUAGE_DEF } from "~/constants/language";
 import { DESIGN_SURVEY_MODE } from "~/routes";
 import {
   addAnswerInstructions,

--- a/src/state/design/saveDebounce.js
+++ b/src/state/design/saveDebounce.js
@@ -9,7 +9,7 @@ let buffer = [];
 let debounceTime = 500;
 let rollbackState = null;
 
-export const saveDebounce = (store) => {
+const saveDebounce = (store) => {
   if (saveTimer) {
     clearTimeout(saveTimer);
   }
@@ -51,7 +51,7 @@ export const dataSaver = (store) => (next) => (action) => {
   return next(action);
 };
 
-export const MUTATING = [
+const MUTATING = [
   "designState/onBaseLangChanged",
   "designState/onAdditionalLangAdded",
   "designState/onAdditionalLangRemoved",
@@ -83,7 +83,7 @@ export const MUTATING = [
   "designState/setDefaultValue",
 ];
 
-export const setState = (store, state) => {
+const setState = (store, state) => {
   store.dispatch(setUpdating(false));
   store.dispatch(designStateReceived(state));
   store.dispatch(setSaving(false));
@@ -97,7 +97,7 @@ export const setState = (store, state) => {
   buffer = [];
 };
 
-export const setError = (store, error) => {
+const setError = (store, error) => {
   // Rollback optimistic updates on error
   if (rollbackState) {
     store.dispatch(
@@ -130,7 +130,7 @@ export const setError = (store, error) => {
   buffer = [];
 };
 
-export const reservedKeys = [
+const reservedKeys = [
   "skipScroll",
   "langInfo",
   "reorder_refresh_code",
@@ -146,7 +146,7 @@ export const reservedKeys = [
   "globalSetup",
 ];
 
-export function getDiff(currentState, latestState) {
+function getDiff(currentState, latestState) {
   const changes = {};
 
   // Get all keys from both objects and filter out reserved keys

--- a/src/state/design/saveDebounce.js
+++ b/src/state/design/saveDebounce.js
@@ -9,7 +9,7 @@ let buffer = [];
 let debounceTime = 500;
 let rollbackState = null;
 
-const saveDebounce = (store) => {
+export const saveDebounce = (store) => {
   if (saveTimer) {
     clearTimeout(saveTimer);
   }
@@ -51,7 +51,7 @@ export const dataSaver = (store) => (next) => (action) => {
   return next(action);
 };
 
-const MUTATING = [
+export const MUTATING = [
   "designState/onBaseLangChanged",
   "designState/onAdditionalLangAdded",
   "designState/onAdditionalLangRemoved",
@@ -83,7 +83,7 @@ const MUTATING = [
   "designState/setDefaultValue",
 ];
 
-const setState = (store, state) => {
+export const setState = (store, state) => {
   store.dispatch(setUpdating(false));
   store.dispatch(designStateReceived(state));
   store.dispatch(setSaving(false));
@@ -97,7 +97,7 @@ const setState = (store, state) => {
   buffer = [];
 };
 
-const setError = (store, error) => {
+export const setError = (store, error) => {
   // Rollback optimistic updates on error
   if (rollbackState) {
     store.dispatch(
@@ -130,7 +130,7 @@ const setError = (store, error) => {
   buffer = [];
 };
 
-const reservedKeys = [
+export const reservedKeys = [
   "skipScroll",
   "langInfo",
   "reorder_refresh_code",
@@ -146,7 +146,7 @@ const reservedKeys = [
   "globalSetup",
 ];
 
-function getDiff(currentState, latestState) {
+export function getDiff(currentState, latestState) {
   const changes = {};
 
   // Get all keys from both objects and filter out reserved keys

--- a/src/state/design/stateUtils.js
+++ b/src/state/design/stateUtils.js
@@ -103,7 +103,7 @@ export const reorder = (list, startIndex, endIndex) => {
   return result;
 };
 
-function collectExistingGroupCodes(groups) {
+export function collectExistingGroupCodes(groups) {
   const ids = new Set();
   if (Array.isArray(groups)) {
     groups.forEach((g) => {
@@ -118,7 +118,7 @@ export const nextGroupId = (groups) => {
   return generateId(existing);
 };
 
-function collectExistingIds(state, groups) {
+export function collectExistingIds(state, groups) {
   const ids = new Set();
 
   groups.forEach((group) => {
@@ -134,13 +134,13 @@ function collectExistingIds(state, groups) {
   return ids;
 }
 
-function randChar(chars) {
+export function randChar(chars) {
   const array = new Uint32Array(1);
   crypto.getRandomValues(array);
   return chars[array[0] % chars.length];
 }
 
-function generateId(existing) {
+export function generateId(existing) {
   const letters = "abcdefghijklmnopqrstuvwxyz";
   const numbers = "0123456789";
   let id = "";
@@ -171,7 +171,7 @@ export const buildReferenceInstruction = (content, name, key, contentPath) => {
   })
 };
 
-const getAllMatches = (inputString) => {
+export const getAllMatches = (inputString) => {
   const regex = /\{\{(.*?)\}\}/g;
   return Array.from(inputString.matchAll(regex), m => m[1].trim());
 };

--- a/src/state/design/stateUtils.js
+++ b/src/state/design/stateUtils.js
@@ -1,5 +1,3 @@
-import { all } from 'axios';
-
 export const buildValidationDefaultData = (rule) => {
   switch (rule) {
     case "validation_required":

--- a/src/utils/design/colorUtils.js
+++ b/src/utils/design/colorUtils.js
@@ -1,0 +1,30 @@
+function hexToRgb(hex) {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r, g, b];
+}
+
+function getLuminance(hexColor) {
+  const [r, g, b] = hexToRgb(hexColor);
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+function getContrastRatio(foreground, background) {
+  const lumA = getLuminance(foreground);
+  const lumB = getLuminance(background);
+  return (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
+}
+
+export const colorToThemeMode = (color) => {
+  const whiteContrast = getContrastRatio(color, "#ffffff");
+  const blackContrast = getContrastRatio(color, "#000000");
+
+  // If white text has better contrast, use dark theme
+  return whiteContrast > blackContrast ? "light" : "dark";
+};

--- a/src/utils/design/pureFunctions.js
+++ b/src/utils/design/pureFunctions.js
@@ -1,0 +1,185 @@
+import {
+  QUESTION_CODE_PATTERN,
+  GROUP_CODE_PATTERN,
+  STRIP_TAGS_PATTERN,
+} from "~/constants/instruction";
+
+export const isEquivalent = (a, b, visited = new WeakSet()) => {
+  if (a === b) return true;
+
+  if (typeof a === "function" || typeof b === "function") {
+    return false;
+  }
+
+  if (typeof a !== "object" || typeof b !== "object") {
+    return a === b;
+  }
+
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  if (visited.has(a) || visited.has(b)) {
+    return true;
+  }
+
+  visited.add(a);
+  visited.add(b);
+
+  const aProps = Object.getOwnPropertyNames(a);
+  const bProps = Object.getOwnPropertyNames(b);
+
+  if (aProps.length !== bProps.length) {
+    return false;
+  }
+
+  for (const prop of aProps) {
+    if (prop !== "key" && !isEquivalent(a[prop], b[prop], visited)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const diff = (obj1, obj2) => {
+  if (!obj2 || Object.prototype.toString.call(obj2) !== "[object Object]") {
+    return obj1;
+  }
+
+  let diffs = {};
+  let key;
+
+  let arraysMatch = function (arr1, arr2) {
+    if (arr1.length !== arr2.length) return false;
+
+    for (var i = 0; i < arr1.length; i++) {
+      if (!isEquivalent(arr1[i], arr2[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const compare = function (item1, item2, key) {
+    let type1 = Object.prototype.toString.call(item1);
+    let type2 = Object.prototype.toString.call(item2);
+
+    if (type2 === "[object Undefined]") {
+      diffs[key] = null;
+      return;
+    }
+
+    if (type1 !== type2) {
+      diffs[key] = item2;
+      return;
+    }
+
+    if (type1 === "[object Object]") {
+      let objDiff = diff(item1, item2);
+      if (Object.keys(objDiff).length > 0) {
+        diffs[key] = objDiff;
+      }
+      return;
+    }
+
+    if (type1 === "[object Array]") {
+      if (!arraysMatch(item1, item2)) {
+        diffs[key] = item2;
+      }
+      return;
+    }
+
+    if (type1 === "[object Function]") {
+      if (item1.toString() !== item2.toString()) {
+        diffs[key] = item2;
+      }
+    } else {
+      if (item1 !== item2) {
+        diffs[key] = item2;
+      }
+    }
+  };
+
+  for (key in obj1) {
+    if (obj1.hasOwnProperty(key)) {
+      compare(obj1[key], obj2[key], key);
+    }
+  }
+
+  for (key in obj2) {
+    if (obj2.hasOwnProperty(key)) {
+      if (!(key in obj1)) {
+        diffs[key] = obj2[key];
+      } else if (obj1[key] !== obj2[key]) {
+        diffs[key] = obj2[key];
+      }
+    }
+  }
+
+  return diffs;
+};
+
+export const nextId = (elements) => {
+  if (elements.length) {
+    let arrayOfIntCodes = elements
+      .filter((el) => el.type != "other")
+      .map((el) => el.code.replace(/^\D+/g, ""))
+      .filter((el) => el.length > 0);
+    if (arrayOfIntCodes.length) {
+      let intCodes = arrayOfIntCodes
+        .map((el) => parseInt(el, 10))
+        .sort(function (a, b) {
+          return a - b;
+        });
+      if (intCodes) {
+        return intCodes[intCodes.length - 1] + 1;
+      }
+    }
+  }
+  return 1;
+};
+
+export const stripTags = (string) => {
+  if (typeof string !== "string") return string;
+  return string
+    .replace(STRIP_TAGS_PATTERN, "")
+    .replace(/\{\{.*?\}\}/g, "{{ ... }}");
+};
+
+export function truncateWithEllipsis(text, maxLength) {
+  if (text?.length > maxLength) {
+    return text.substring(0, maxLength) + "...";
+  } else {
+    return text;
+  }
+}
+
+export const isQuestion = (code) => QUESTION_CODE_PATTERN.test(code);
+export const isGroup = (code) => GROUP_CODE_PATTERN.test(code);
+
+export const lastIndexInArray = (array, func) => {
+  if (!array) {
+    return -1;
+  }
+  let index = array.length - 1;
+  for (; index >= 0; index--) {
+    if (func(array[index])) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+export const firstIndexInArray = (array, func) => {
+  if (!array) {
+    return -1;
+  }
+  for (let index = 0; index < array.length; index++) {
+    if (func(array[index])) {
+      return index;
+    }
+  }
+  return -1;
+};


### PR DESCRIPTION
## Summary
- Extract reducer logic from `designState.js` into named, exported functions across new modules (`componentFactories.js`, `pureFunctions.js`, `colorUtils.js`)
- Decouple design state from browser dependencies (e.g., `window`, `document`) for Node.js compatibility
- Export previously private helper functions from `addInstructions.js` for reuse and testability

## Test plan
- [x] Verify survey editor loads and all design operations (add/remove/reorder components, undo/redo, copy/paste) work as before
- [x] Verify survey preview/run is unaffected
- [x] Confirm no regressions in theme handling or color utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)