### PR TITLE
fix: add missing navigation tooltip translations

### DIFF
--- a/public/locales/ar/design/core.json
+++ b/public/locales/ar/design/core.json
@@ -398,5 +398,11 @@
     "search": "بحث...",
     "no_options": "لا توجد خيارات",
     "range_error": "نطاق غير صالح: الحد الأدنى يتجاوز الحد الأقصى"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/de/design/core.json
+++ b/public/locales/de/design/core.json
@@ -398,5 +398,11 @@
     "search": "Suchen...",
     "no_options": "Keine Optionen gefunden",
     "range_error": "Ungültiger Bereich: Minimum überschreitet Maximum"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/en/design/core.json
+++ b/public/locales/en/design/core.json
@@ -398,5 +398,11 @@
     "search": "Search...",
     "no_options": "No options found",
     "range_error": "Invalid range: min exceeds max"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/es/design/core.json
+++ b/public/locales/es/design/core.json
@@ -398,5 +398,11 @@
     "search": "Buscar...",
     "no_options": "No se encontraron opciones",
     "range_error": "Rango inválido: el mínimo supera el máximo"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/fr/design/core.json
+++ b/public/locales/fr/design/core.json
@@ -398,5 +398,11 @@
     "search": "Rechercher...",
     "no_options": "Aucune option trouvée",
     "range_error": "Plage invalide : le minimum dépasse le maximum"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/nl/design/core.json
+++ b/public/locales/nl/design/core.json
@@ -398,5 +398,11 @@
     "search": "Zoeken...",
     "no_options": "Geen opties gevonden",
     "range_error": "Ongeldig bereik: minimum overschrijdt maximum"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }

--- a/public/locales/pt/design/core.json
+++ b/public/locales/pt/design/core.json
@@ -398,5 +398,11 @@
     "search": "Pesquisar...",
     "no_options": "Nenhuma opção encontrada",
     "range_error": "Intervalo inválido: mínimo excede o máximo"
+  },
+  "tooltips": {
+    "allow_previous": "Allow respondents to go back to previous pages during the survey.",
+    "allow_incomplete": "Allow respondents to save their progress and resume the survey later.",
+    "allow_jump": "Allow respondents to jump to any page using a survey index/table of contents.",
+    "skip_invalid": "Skip validation errors while navigating and only enforce them when the survey is submitted."
   }
 }


### PR DESCRIPTION
## Summary
- The 4 navigation setting tooltips (Allow Previous, Allow Incomplete/Resume, Allow Jump, Enforce validation only on submit) were displaying raw i18n keys (`tooltips.allow_previous`, etc.) instead of descriptive text
- Added the missing `tooltips` section to `design/core.json` across all 7 locales (en, ar, de, es, fr, nl, pt)
- Non-English locales currently have English fallback text and can be translated later

## Test plan
- [x] Open a survey editor and navigate to the Navigation settings section
- [x] Hover over the tooltip icons next to the 4 toggle switches
- [ ] Verify each tooltip displays descriptive text instead of a raw key

🤖 Generated with [Claude Code](https://claude.com/claude-code)