### PR TITLE
fix: delay design tour and only show for new/empty surveys

### DIFF
--- a/src/components/design/DesignTour/index.jsx
+++ b/src/components/design/DesignTour/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import introJs from "intro.js";
 import "intro.js/introjs.css";
@@ -18,7 +19,7 @@ const TOUR_STORAGE_KEY = "design_tour_completed";
 const QUESTION_TYPES_STEP = 2;
 const QUESTION_TYPES_SELECTOR = '[data-tour="question-types-list"]';
 // Allow time for virtualized lists and lazy components to mount before starting tour
-const TOUR_START_DELAY_MS = 500;
+const TOUR_START_DELAY_MS = 2000;
 const REMIND_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">' +
   '<path d="M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 ' +
@@ -53,12 +54,28 @@ function unclampQuestionTypes() {
   }
 }
 
+function isSurveyEmpty(designState) {
+  const groups = designState.Survey?.children;
+  if (!groups || groups.length === 0) return true;
+
+  const regularGroups = groups.filter(
+    (g) => designState[g.code]?.groupType === "GROUP"
+  );
+
+  if (regularGroups.length !== 1) return false;
+
+  const regularGroup = designState[regularGroups[0].code];
+  return !regularGroup?.children || regularGroup.children.length === 0;
+}
+
 export default function DesignTourProvider({ children }) {
   const { t } = useTranslation(NAMESPACES.DESIGN_CORE);
   const introInstanceRef = useRef(null);
+  const designState = useSelector((state) => state.designState);
 
   useEffect(() => {
     if (localStorage.getItem(TOUR_STORAGE_KEY) === "true") return;
+    if (!isSurveyEmpty(designState)) return;
 
     const rtl = isSessionRtl();
     const tourSteps = getDesignTourSteps(t);
@@ -170,7 +187,7 @@ export default function DesignTourProvider({ children }) {
       }
       unclampQuestionTypes();
     };
-  }, []);
+  }, [designState]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- Increased tour start delay from 500ms to 2000ms for smoother UX
- Tour now only appears for new/empty surveys (1 empty group + end group), skipping surveys that already have content