### PR TITLE
fix: hide question separators around hidden questions

### DIFF
--- a/src/components/Group/GroupDesign.jsx
+++ b/src/components/Group/GroupDesign.jsx
@@ -11,6 +11,17 @@ import { useDispatch } from "react-redux";
 import { onDrag, setup } from "~/state/design/designState";
 import { DESIGN_SURVEY_MODE } from "~/routes";
 import { setupOptions } from "~/constants/design";
+function QuestionDivider({ currentCode, nextCode }) {
+  const isCurrentHidden = useSelector(
+    (state) => state.designState[currentCode]?.relevance?.rule === "hide_always"
+  );
+  const isNextHidden = useSelector(
+    (state) => state.designState[nextCode]?.relevance?.rule === "hide_always"
+  );
+  if (isCurrentHidden || isNextHidden) return null;
+  return <Divider sx={{ mt: "12px", mb: "12px" }} />;
+}
+
 function GroupDesign({ t, code, index, designMode, lastAddedComponent, isLastGroup }) {
   const dispatch = useDispatch();
   const group = useSelector((state) => {
@@ -202,7 +213,10 @@ function GroupDesign({ t, code, index, designMode, lastAddedComponent, isLastGro
                 t={t}
               />
               {childIndex < children.length - 1 && (
-                <Divider sx={{ mt: "12px", mb: "12px" }} />
+                <QuestionDivider
+                  currentCode={quest.code}
+                  nextCode={children[childIndex + 1].code}
+                />
               )}
             </React.Fragment>
           );

--- a/src/components/Group/index.jsx
+++ b/src/components/Group/index.jsx
@@ -10,15 +10,26 @@ import { Box, Divider, useTheme } from "@mui/material";
 function Group(props) {
   const theme = useTheme();
 
-  const state = useSelector((state) => {
+  const showGroup = useSelector((state) => {
     let groupState = state.runState.values[props.group.code];
-    return {
-      showGroup:
-        typeof groupState?.relevance === "undefined" || groupState.relevance,
-    };
+    return typeof groupState?.relevance === "undefined" || groupState.relevance;
+  });
+
+  const visibleQuestionCodes = useSelector((state) => {
+    return (props.group?.questions ?? [])
+      .filter((quest) => {
+        if (!quest.inCurrentNavigation) return false;
+        const q = state.runState.values[quest.qualifiedCode];
+        return typeof q?.relevance === "undefined" || !!q?.relevance;
+      })
+      .map((q) => q.qualifiedCode);
   }, shallowEqual);
 
-  const showGroup = () => {
+  const showGroup_ = () => {
+    const visibleCodesSet = new Set(visibleQuestionCodes);
+    const visibleQuestions = (props.group?.questions ?? []).filter((quest) =>
+      visibleCodesSet.has(quest.qualifiedCode)
+    );
     return (
       <>
         <Box
@@ -55,26 +66,19 @@ function Group(props) {
               )}
           </div>
 
-          {props.group && props.group.questions
-            ? (() => {
-                const visibleQuestions = props.group.questions.filter(
-                  (quest) => quest.inCurrentNavigation
-                );
-                return visibleQuestions.map((quest, idx) => (
-                  <React.Fragment key={quest.code}>
-                    <Question component={quest} />
-                    {idx < visibleQuestions.length - 1 && (
-                      <Divider sx={{ mt: "12px", mb: "12px" }} />
-                    )}
-                  </React.Fragment>
-                ));
-              })()
-            : ""}
+          {visibleQuestions.map((quest, idx) => (
+            <React.Fragment key={quest.code}>
+              <Question component={quest} />
+              {idx < visibleQuestions.length - 1 && (
+                <Divider sx={{ mt: "12px", mb: "12px" }} />
+              )}
+            </React.Fragment>
+          ))}
         </Box>
       </>
     );
   };
-  return state.showGroup && (props.group ? showGroup() : "");
+  return showGroup && (props.group ? showGroup_() : "");
 }
 
 export default React.memo(Group);


### PR DESCRIPTION
## Summary
- In the **design editor**, a `QuestionDivider` component now checks if either adjacent question has `hide_always` relevance and suppresses the divider accordingly
- In the **run view**, `visibleQuestions` is now filtered by both `inCurrentNavigation` and run-state relevance, so hidden questions are fully excluded and dividers render correctly between visible questions only