### PR TITLE
fix: center array column labels in RTL design view

### DIFF
--- a/src/components/Questions/SCQArray/ArrayDesign.jsx
+++ b/src/components/Questions/SCQArray/ArrayDesign.jsx
@@ -460,24 +460,26 @@ function ArrayHeaderDesign({
           </div>
         </div>
       )}
-      <ContentEditor
-        code={item.qualifiedCode}
-        showToolbar={false}
-        editable={contentEditable(designMode)}
-        extended={false}
-        centerText
-        placeholder={
-          onMainLang
-            ? t("content_editor_placeholder_option", {
-                lng: langInfo.mainLang,
-              })
-            : mainContent ||
-              t("content_editor_placeholder_option", {
-                lng: langInfo.mainLang,
-              })
-        }
-        contentKey="label"
-      />
+      <div className="array-column-header">
+        <ContentEditor
+          code={item.qualifiedCode}
+          showToolbar={false}
+          editable={contentEditable(designMode)}
+          extended={false}
+          centerText
+          placeholder={
+            onMainLang
+              ? t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+              : mainContent ||
+                t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+          }
+          contentKey="label"
+        />
+      </div>
     </TableCell>
   );
 }

--- a/src/styles/tiptap-editor.css
+++ b/src/styles/tiptap-editor.css
@@ -366,6 +366,11 @@
   text-align: right !important;
 }
 
+.array-column-header .content-editor.rtl,
+.array-column-header .content-editor.ltr {
+  text-align: center !important;
+}
+
 .content-editor .tiptap-image,
 .content-editor .tiptap-image img {
   max-width: 100%;


### PR DESCRIPTION
## Summary
- Add scoped `.array-column-header` CSS rule to center column labels in RTL array questions (design view only)
- Wrap `ContentEditor` in `ArrayDesign.jsx` with the new class to override `.content-editor.rtl`'s `text-align: right !important`

<img width="908" height="565" alt="image" src="https://github.com/user-attachments/assets/5e1845c1-1d4f-4ba8-82cd-3f313b0c4521" />

## Test plan
- [ ] Open an array question in the design view with an RTL language (Arabic)
- [ ] Confirm column labels are centered
- [ ] Preview the survey and confirm column labels still display correctly
- [ ] Verify LTR design view is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)