### PR TITLE
fix: stack ranking question columns vertically on mobile

### DIFF
--- a/src/components/Questions/Ranking/Ranking.jsx
+++ b/src/components/Questions/Ranking/Ranking.jsx
@@ -190,13 +190,7 @@ function Ranking(props) {
   };
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "1fr 1fr",
-        gap: "16px",
-      }}
-    >
+    <div className={styles.grid}>
       <div className={styles.column}>
         <div className={styles.columnHeader}>
           <Typography variant="subtitle2" sx={{ color: "text.secondary" }}>

--- a/src/components/Questions/Ranking/Ranking.module.css
+++ b/src/components/Questions/Ranking/Ranking.module.css
@@ -1,3 +1,15 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .column {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- The ranking question's two-column grid layout (Options remaining / Your Ranking) was fixed at `1fr 1fr` on all screen sizes, making items cramped and hard to interact with on mobile
- Added a CSS media query (`max-width: 600px`) to switch to a single-column stacked layout on small screens

## Test plan
- [ ] Open a survey with a ranking question on a mobile viewport (< 600px)
- [ ] Confirm the Options and Your Ranking sections stack vertically
- [ ] Confirm two-column layout remains on desktop (> 600px)
- [ ] Test drag-and-drop works in both layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)