### PR TITLE
fix: make matrix question horizontally scrollable on mobile

### DIFF
--- a/src/components/Group/Group.module.css
+++ b/src/components/Group/Group.module.css
@@ -27,6 +27,7 @@
   padding: 10px;
   margin: auto;
   position: relative;
+  overflow: hidden;
 }
 
 @media (min-width: 600px) {

--- a/src/components/Question/Question.module.css
+++ b/src/components/Question/Question.module.css
@@ -26,6 +26,8 @@
   border-radius: 6px;
   page-break-inside: avoid;
   transition: all 200ms cubic-bezier(0, 0, 0.2, 1);
+  min-width: 0;
+  overflow: hidden;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- Fix matrix (array) questions being cut off on mobile with no horizontal scroll
- Add `min-width: 0` and `overflow: hidden` to `.groupQuestion` so the flex item can shrink below the table's intrinsic width
- Add `overflow: hidden` to `.topLevel` to prevent the group container from overflowing the viewport

Root cause: flexbox `min-width: auto` default prevented `TableContainer`'s `overflowX: "auto"` from triggering.

## Test plan
- [ ] Open a survey with a matrix question (4+ columns) on a mobile viewport or Chrome DevTools mobile emulation
- [ ] Confirm the matrix table is horizontally scrollable
- [ ] Confirm non-matrix questions still render correctly (no unexpected clipping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)