### PR TITLE
fix: translate design page labels based on survey language

### DIFF
--- a/src/components/design/ContentPanel/index.jsx
+++ b/src/components/design/ContentPanel/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import styles from "./ContentPanel.module.css";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
@@ -13,8 +13,22 @@ import { resetSetup } from "~/state/design/designState";
 import { DESIGN_SURVEY_MODE } from "~/routes";
 
 function ContentPanel({ designMode }, ref) {
-  const { t } = useTranslation(NAMESPACES.DESIGN_CORE);
+  const { i18n } = useTranslation(NAMESPACES.DESIGN_CORE);
   const theme = useTheme();
+  const lang = useSelector((state) => state.designState.langInfo?.lang);
+  const [langReady, setLangReady] = useState(false);
+
+  useEffect(() => {
+    if (lang) {
+      setLangReady(false);
+      i18n.loadLanguages([lang]).then(() => setLangReady(true));
+    }
+  }, [lang, i18n]);
+
+  const t = useCallback(
+    (key, options) => i18n.getFixedT(lang, NAMESPACES.DESIGN_CORE)(key, options),
+    [lang, i18n, langReady]
+  );
 
   const groups = useSelector((state) => {
     return state.designState["Survey"]?.children || [];
@@ -177,7 +191,7 @@ function ContentPanel({ designMode }, ref) {
               case ELEMENTS.GROUP:
                 return (
                   <>
-                    <div className={styles.groupLabel}>{item.label}</div>
+                    <div className={styles.groupLabel} dir="auto">{item.label}</div>
                     <GroupDesign
                       t={t}
                       key={item.group.code}

--- a/src/pages/DesignSurvey/index.jsx
+++ b/src/pages/DesignSurvey/index.jsx
@@ -4,7 +4,7 @@ import styles from "./DesignSurvey.module.css";
 
 import { defualtTheme } from "~/constants/theme";
 import { useTranslation } from "react-i18next";
-import { NAMESPACES } from "~/hooks/useNamespaceLoader";
+import useNamespaceLoader, { NAMESPACES } from "~/hooks/useNamespaceLoader";
 import { cacheRtl, rtlLanguage } from "~/utils/common";
 import { CacheProvider } from "@emotion/react";
 import { useDispatch, useSelector } from "react-redux";
@@ -28,6 +28,7 @@ const ContentPanel = React.lazy(() =>
 const LeftPanel = React.lazy(() => import("~/components/design/LeftPanel"));
 
 function DesignSurvey() {
+  useNamespaceLoader();
   const { t } = useTranslation(NAMESPACES.DESIGN_CORE);
   const [contentElement, setContentElement] = React.useState(null);
   const dispatch = useDispatch();


### PR DESCRIPTION
## Summary
- Add `useNamespaceLoader()` to `DesignSurvey` so design translation namespaces load on direct page reload (not just when navigating from home)
- Load translations for the selected survey language in `ContentPanel` using `i18n.loadLanguages()` and `getFixedT()` so page labels (Page 1, Welcome Page, Thank You Page) update when switching language from the sidebar
- Add `dir="auto"` to group labels for correct RTL text alignment

## Test plan
- [ ] Navigate from home to design page — labels should show in correct language
- [ ] Directly reload the design page — labels should still translate correctly
- [ ] Switch survey language from the sidebar — labels should update to the selected language
- [ ] Test with RTL language (Arabic) — labels should be right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)