### PR TITLE
refactor: use explicit extensions and relative paths in designState imports

### DIFF
--- a/src/state/design/convertArrayQuestion.js
+++ b/src/state/design/convertArrayQuestion.js
@@ -1,10 +1,10 @@
-import { ARRAY_MIN_WIDTH_KEYS } from "~/constants/design";
+import { ARRAY_MIN_WIDTH_KEYS } from "../../constants/design.js";
 import {
   addAnswerInstructions,
   changeInstruction,
   refreshEnumForSingleChoice,
   refreshListForMultipleChoice,
-} from "./addInstructions";
+} from "./addInstructions.js";
 
 export function convertArrayQuestion(
   state,

--- a/src/state/design/convertChoiceQuestion.js
+++ b/src/state/design/convertChoiceQuestion.js
@@ -1,4 +1,4 @@
-import { isSingleSelect, mediaGroup } from "~/constants/design";
+import { isSingleSelect, mediaGroup } from "../../constants/design.js";
 import {
   addAnswerInstructions,
   addMaskedValuesInstructions,
@@ -8,7 +8,7 @@ import {
   refreshEnumForSingleChoice,
   refreshListForMultipleChoice,
   removeInstruction,
-} from "./addInstructions";
+} from "./addInstructions.js";
 
 export function convertChoiceQuestion(
   state,

--- a/src/state/design/convertTextQuestion.js
+++ b/src/state/design/convertTextQuestion.js
@@ -1,5 +1,5 @@
-import { setupOptions } from "~/constants/design";
-import { removeInstruction } from "./addInstructions";
+import { setupOptions } from "../../constants/design.js";
+import { removeInstruction } from "./addInstructions.js";
 
 export function convertTextQuestion(currentQuestion, newType) {
   if (!currentQuestion.validation) return;

--- a/src/state/design/designState.js
+++ b/src/state/design/designState.js
@@ -1,8 +1,8 @@
 import { createSlice, current } from "@reduxjs/toolkit";
-import { firstIndexInArray, isEquivalent, nextId } from "~/utils/design/utils";
-import { createGroup } from "~/components/design/NewComponentsPanel";
+import { firstIndexInArray, isEquivalent, nextId } from "../../utils/design/utils.js";
+import { createGroup } from "../../components/design/NewComponentsPanel/index.jsx";
 
-import { lastIndexInArray } from "~/utils/design/utils";
+import { lastIndexInArray } from "../../utils/design/utils.js";
 import cloneDeep from "lodash.clonedeep";
 import {
   buildValidationDefaultData,
@@ -10,7 +10,7 @@ import {
   nextQuestionId,
   reorder,
   buildReferenceInstruction,
-} from "./stateUtils";
+} from "./stateUtils.js";
 import {
   CONVERTIBLE_CHOICE_TYPES,
   CONVERTIBLE_ARRAY_TYPES,
@@ -19,16 +19,16 @@ import {
   languageSetup,
   setupOptions,
   themeSetup,
-} from "~/constants/design";
-import { convertChoiceQuestion } from "./convertChoiceQuestion";
-import { convertArrayQuestion } from "./convertArrayQuestion";
-import { convertTextQuestion } from "./convertTextQuestion";
-import { convertDateTimeQuestion } from "./convertDateTimeQuestion";
+} from "../../constants/design.js";
+import { convertChoiceQuestion } from "./convertChoiceQuestion.js";
+import { convertArrayQuestion } from "./convertArrayQuestion.js";
+import { convertTextQuestion } from "./convertTextQuestion.js";
+import { convertDateTimeQuestion } from "./convertDateTimeQuestion.js";
 import {
   createQuestion,
   questionDesignError,
-} from "~/components/Questions/utils";
-import { DESIGN_SURVEY_MODE } from "~/routes";
+} from "../../components/Questions/utils.jsx";
+import { DESIGN_SURVEY_MODE } from "../../routes.js";
 import {
   addAnswerInstructions,
   addMaskedValuesInstructions,
@@ -43,8 +43,8 @@ import {
   processValidation,
   removeInstruction,
   updateRandomByRule,
-} from "./addInstructions";
-import { defaultSurveyTheme } from "~/constants/theme";
+} from "./addInstructions.js";
+import { defaultSurveyTheme } from "../../constants/theme.js";
 
 const reservedKeys = [
   "setup",


### PR DESCRIPTION
## Summary
- Replace `~/` aliases and extensionless imports in `designState.js` and the three `convert*Question.js` files with relative paths and explicit extensions
- Lets Node ESM consumers (e.g. the `ai/` service in `qlarr-surveys/frontend-cloud`) load these modules without Vite's resolver
- No behavioural change — Vite resolves both forms identically

## Caveat
Upstream has no Node ESM consumer today, and two of the updated specifiers resolve to `.jsx` files (`NewComponentsPanel/index.jsx`, `Questions/utils.jsx`) that Node ESM would still not load without a loader. This PR is primarily a convention alignment with the cloud repo.

## Test plan
- [ ] `npm start` boots the dev server cleanly
- [ ] `npm run build` succeeds
- [ ] Design page loads; question-type conversion between choice/array/text/datetime still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)