### PR TITLE
fix: redirect to login instead of blank page on unauthenticated survey access

### DIFF
--- a/src/Web.jsx
+++ b/src/Web.jsx
@@ -1,6 +1,5 @@
 import React, { Suspense } from "react";
 import {
-  Navigate,
   Route,
   Routes,
   useLocation,
@@ -12,12 +11,12 @@ import { lazy } from "react";
 import { runStore } from "./store";
 import { Provider } from "react-redux";
 
-import TokenService from "./services/TokenService";
 import { getparam } from "./networking/run";
 
 import LoadingIndicator from "./components/common/LoadingIndicator";
 import { ROLES } from "./constants/roles";
 import { HEADER_OPTIONS } from './pages/ManagePageWrapper/headerOptions';
+import { ACCESS } from './pages/ManagePageWrapper/access';
 
 const AuthIllustrationLayout = lazy(() => import("./layouts/authlayout"));
 const ManagePageWrapper = lazy(() => import("./pages/ManagePageWrapper"));
@@ -101,8 +100,8 @@ function Web() {
         path={routes.preview}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <ManagePageWrapper  headerOptions={HEADER_OPTIONS.NONE}>
-              <PrivatePreviewSurvey />
+            <ManagePageWrapper headerOptions={HEADER_OPTIONS.NONE}>
+              <PreviewSurveyContent />
             </ManagePageWrapper>
           </Suspense>
         }
@@ -112,7 +111,7 @@ function Web() {
         element={
           <Suspense fallback={<LoadingIndicator />}>
             <ManagePageWrapper headerOptions={HEADER_OPTIONS.NONE}>
-              <PrivatePreviewSurvey />
+              <PreviewSurveyContent />
             </ManagePageWrapper>
           </Suspense>
         }
@@ -144,11 +143,12 @@ function Web() {
         path={routes.manageUsers}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <PrivateManageUsers roles={[ROLES.SUPER_ADMIN]}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
-                <ManageUsers />
-              </ManagePageWrapper>
-            </PrivateManageUsers>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.GENERAL}
+              requiredRoles={[ROLES.SUPER_ADMIN]}
+            >
+              <ManageUsers />
+            </ManagePageWrapper>
           </Suspense>
         }
       />
@@ -156,11 +156,9 @@ function Web() {
         path={routes.profile}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <PrivateComponent>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
-                <ProfileView />
-              </ManagePageWrapper>
-            </PrivateComponent>
+            <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
+              <ProfileView />
+            </ManagePageWrapper>
           </Suspense>
         }
       />
@@ -168,11 +166,12 @@ function Web() {
         path={routes.createSurvey}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <PrivateManageUsers roles={[ROLES.SUPER_ADMIN, ROLES.SUPER_ADMIN]}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
-                <CreateSurvey />
-              </ManagePageWrapper>
-            </PrivateManageUsers>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.GENERAL}
+              requiredRoles={[ROLES.SUPER_ADMIN]}
+            >
+              <CreateSurvey />
+            </ManagePageWrapper>
           </Suspense>
         }
       />
@@ -188,11 +187,9 @@ function Web() {
         path={routes.dashboard}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <PrivateComponent>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
-                <Dashboard />
-              </ManagePageWrapper>
-            </PrivateComponent>
+            <ManagePageWrapper headerOptions={HEADER_OPTIONS.GENERAL}>
+              <Dashboard />
+            </ManagePageWrapper>
           </Suspense>
         }
       />
@@ -200,53 +197,57 @@ function Web() {
       <Route
         path={routes.login}
         element={
-          <PublicOnlyRoute>
-            <Suspense fallback={<LoadingIndicator />}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.AUTH}>
-                <AuthIllustrationLayout>
-                  <LoginView />
-                </AuthIllustrationLayout>
-              </ManagePageWrapper>
-            </Suspense>
-          </PublicOnlyRoute>
+          <Suspense fallback={<LoadingIndicator />}>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.AUTH}
+              access={ACCESS.GUEST}
+            >
+              <AuthIllustrationLayout>
+                <LoginView />
+              </AuthIllustrationLayout>
+            </ManagePageWrapper>
+          </Suspense>
         }
       />
       <Route
         path={routes.forgotPassword}
         element={
-          <PublicOnlyRoute>
-            <Suspense fallback={<LoadingIndicator />}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.AUTH}>
-                <AuthIllustrationLayout>
-                  <ForgotPasswordView />
-                </AuthIllustrationLayout>
-              </ManagePageWrapper>
-            </Suspense>
-          </PublicOnlyRoute>
+          <Suspense fallback={<LoadingIndicator />}>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.AUTH}
+              access={ACCESS.GUEST}
+            >
+              <AuthIllustrationLayout>
+                <ForgotPasswordView />
+              </AuthIllustrationLayout>
+            </ManagePageWrapper>
+          </Suspense>
         }
       />
       <Route
         path={routes.resetPassword}
         element={
-          <PublicOnlyRoute>
-            <Suspense fallback={<LoadingIndicator />}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.AUTH}>
-                <ResetPasswordView />
-              </ManagePageWrapper>
-            </Suspense>
-          </PublicOnlyRoute>
+          <Suspense fallback={<LoadingIndicator />}>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.AUTH}
+              access={ACCESS.GUEST}
+            >
+              <ResetPasswordView />
+            </ManagePageWrapper>
+          </Suspense>
         }
       />
       <Route
         path={routes.confirmNewUser}
         element={
-          <PublicOnlyRoute>
-            <Suspense fallback={<LoadingIndicator />}>
-              <ManagePageWrapper headerOptions={HEADER_OPTIONS.AUTH}>
-                <ResetPasswordView confirmNewUser={true} />
-              </ManagePageWrapper>
-            </Suspense>
-          </PublicOnlyRoute>
+          <Suspense fallback={<LoadingIndicator />}>
+            <ManagePageWrapper
+              headerOptions={HEADER_OPTIONS.AUTH}
+              access={ACCESS.GUEST}
+            >
+              <ResetPasswordView confirmNewUser={true} />
+            </ManagePageWrapper>
+          </Suspense>
         }
       />
     </Routes>
@@ -254,14 +255,8 @@ function Web() {
 }
 
 const PrivateDesignSurvey = ({ landingPage, headerOptions }) => {
-  const params = useParams();
-  const location = useLocation();
-
-  if (!TokenService.isAuthenticated()) {
-    return <Navigate to="/login" replace state={{ from: location }} />;
-  }
-
-  sessionStorage.setItem("surveyId", params.surveyId);
+  const { surveyId } = useParams();
+  sessionStorage.setItem("surveyId", surveyId);
 
   return (
     <ManagePageWrapper headerOptions={headerOptions}>
@@ -270,50 +265,11 @@ const PrivateDesignSurvey = ({ landingPage, headerOptions }) => {
   );
 };
 
-const PrivatePreviewSurvey = () => {
+const PreviewSurveyContent = () => {
   const params = useParams();
   sessionStorage.setItem("surveyId", params.surveyId);
-  const location = useLocation();
-  const responseId = getparam(useParams(), "responseId");
-  return TokenService.isAuthenticated() ? (
-    <PreviewSurvey responseId={responseId} />
-  ) : (
-    <Navigate to="/login" replace state={{ from: location }} />
-  );
-};
-
-const PrivateComponent = ({ children }) => {
-  const location = useLocation();
-  return TokenService.isAuthenticated() ? (
-    children
-  ) : (
-    <Navigate to="/login" replace state={{ from: location }} />
-  );
-};
-
-const PrivateManageUsers = ({ roles, children }) => {
-  const location = useLocation();
-
-  if (!TokenService.isAuthenticated()) {
-    return <Navigate to="/login" replace state={{ from: location }} />;
-  }
-
-  const user = TokenService.getUser();
-  const hasCorrectRole = user.roles.some((el) => roles.indexOf(el) > -1);
-
-  if (!hasCorrectRole) {
-    return <Navigate to="/" replace />;
-  }
-
-  return children;
-};
-
-const PublicOnlyRoute = ({ children }) => {
-  return TokenService.isAuthenticated() ? (
-    <Navigate to="/" replace />
-  ) : (
-    children
-  );
+  const responseId = getparam(params, "responseId");
+  return <PreviewSurvey responseId={responseId} />;
 };
 
 const RunSurveyWrapper = ({ resume = false }) => {

--- a/src/Web.jsx
+++ b/src/Web.jsx
@@ -90,11 +90,10 @@ function Web() {
         path={routes.designSurvey}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <ManagePageWrapper headerOptions={HEADER_OPTIONS.SURVEY}>
-              <PrivateDesignSurvey
-                landingPage={MANAGE_SURVEY_LANDING_PAGES.DESIGN}
-              />
-            </ManagePageWrapper>
+            <PrivateDesignSurvey
+              landingPage={MANAGE_SURVEY_LANDING_PAGES.DESIGN}
+              headerOptions={HEADER_OPTIONS.SURVEY}
+            />
           </Suspense>
         }
       />
@@ -122,11 +121,10 @@ function Web() {
         path={routes.editSurvey}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <ManagePageWrapper headerOptions={HEADER_OPTIONS.SURVEY}>
-              <PrivateDesignSurvey
-                landingPage={MANAGE_SURVEY_LANDING_PAGES.SETTINGS}
-              />
-            </ManagePageWrapper>
+            <PrivateDesignSurvey
+              landingPage={MANAGE_SURVEY_LANDING_PAGES.SETTINGS}
+              headerOptions={HEADER_OPTIONS.SURVEY}
+            />
           </Suspense>
         }
       />
@@ -135,11 +133,10 @@ function Web() {
         path={routes.responses}
         element={
           <Suspense fallback={<LoadingIndicator />}>
-            <ManagePageWrapper headerOptions={HEADER_OPTIONS.SURVEY_NO_PREVIEW}>
-              <PrivateDesignSurvey
-                landingPage={MANAGE_SURVEY_LANDING_PAGES.RESPONSES}
-              />
-            </ManagePageWrapper>
+            <PrivateDesignSurvey
+              landingPage={MANAGE_SURVEY_LANDING_PAGES.RESPONSES}
+              headerOptions={HEADER_OPTIONS.SURVEY_NO_PREVIEW}
+            />
           </Suspense>
         }
       />
@@ -256,14 +253,20 @@ function Web() {
   );
 }
 
-const PrivateDesignSurvey = ({ landingPage }) => {
+const PrivateDesignSurvey = ({ landingPage, headerOptions }) => {
   const params = useParams();
-  sessionStorage.setItem("surveyId", params.surveyId);
   const location = useLocation();
-  return TokenService.isAuthenticated() ? (
-    <ManageSurvey landingPage={landingPage} />
-  ) : (
-    <Navigate to="/login" replace state={{ from: location }} />
+
+  if (!TokenService.isAuthenticated()) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  sessionStorage.setItem("surveyId", params.surveyId);
+
+  return (
+    <ManagePageWrapper headerOptions={headerOptions}>
+      <ManageSurvey landingPage={landingPage} />
+    </ManagePageWrapper>
   );
 };
 
@@ -290,23 +293,19 @@ const PrivateComponent = ({ children }) => {
 
 const PrivateManageUsers = ({ roles, children }) => {
   const location = useLocation();
+
+  if (!TokenService.isAuthenticated()) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
   const user = TokenService.getUser();
-  let hasCorrectRole = false;
-  user.roles.forEach((el) => {
-    if (roles.indexOf(el) > -1) {
-      hasCorrectRole = true;
-    }
-  });
+  const hasCorrectRole = user.roles.some((el) => roles.indexOf(el) > -1);
 
   if (!hasCorrectRole) {
     return <Navigate to="/" replace />;
   }
 
-  return TokenService.isAuthenticated() ? (
-    children
-  ) : (
-    <Navigate to="/login" replace state={{ from: location }} />
-  );
+  return children;
 };
 
 const PublicOnlyRoute = ({ children }) => {

--- a/src/constants/roles.js
+++ b/src/constants/roles.js
@@ -9,7 +9,8 @@ export const ROLES = {
 };
 
 export const isSurveyAdmin = () => {
-  const roles = TokenService.getUser().roles;
+  const roles = TokenService.getUser()?.roles;
+  if (!roles) return false;
   return (
     roles.indexOf(ROLES.SUPER_ADMIN) != -1 ||
     roles.indexOf(ROLES.SURVEY_ADMIN) != -1
@@ -33,7 +34,8 @@ export const availablePages = (user) => {
 };
 
 export const isSuperAdmin = () => {
-  const roles = TokenService.getUser().roles;
+  const roles = TokenService.getUser()?.roles;
+  if (!roles) return false;
   return (
     roles.indexOf(ROLES.SUPER_ADMIN) != -1
   );
@@ -55,6 +57,7 @@ export const isAnalyst = (user) => {
 };
 
 export const isSurveyorOnly = () => {
-  const roles = TokenService.getUser().roles;
+  const roles = TokenService.getUser()?.roles;
+  if (!roles) return false;
   return roles.length == 1 && roles.indexOf(ROLES.SURVEYOR) != -1;
 };

--- a/src/pages/ManagePageWrapper/access.js
+++ b/src/pages/ManagePageWrapper/access.js
@@ -1,0 +1,5 @@
+export const ACCESS = {
+  AUTH: "auth",
+  GUEST: "guest",
+  ANY: "any",
+};

--- a/src/pages/ManagePageWrapper/index.jsx
+++ b/src/pages/ManagePageWrapper/index.jsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useMemo, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
 import { cacheRtl, setLangFromSession } from "~/utils/common";
 import { CacheProvider } from "@emotion/react";
 import { useTranslation } from "react-i18next";
@@ -11,9 +12,17 @@ import { StatefulLoadingIndicator } from "~/components/common/LoadingIndicator";
 import ThemeProvider from "~/theme";
 import UnsupportedView from "../UnsupportedView";
 import useNamespaceLoader, { NAMESPACES } from "~/hooks/useNamespaceLoader";
+import TokenService from "~/services/TokenService";
 import { HEADER_OPTIONS } from "./headerOptions";
+import { ACCESS } from "./access";
 
-const ManagePageWrapper = ({ headerOptions = HEADER_OPTIONS.GENERAL, children }) => {
+const ManagePageWrapper = ({
+  headerOptions = HEADER_OPTIONS.GENERAL,
+  access = ACCESS.AUTH,
+  requiredRoles,
+  children,
+}) => {
+  const location = useLocation();
   const lang = localStorage.getItem("lang");
 
   const { i18n } = useTranslation(NAMESPACES.MANAGE);
@@ -52,6 +61,25 @@ const ManagePageWrapper = ({ headerOptions = HEADER_OPTIONS.GENERAL, children })
       window.removeEventListener("resize", checkScreenSize);
     };
   }, []);
+
+  const isAuthenticated = TokenService.isAuthenticated();
+
+  if (access === ACCESS.AUTH && !isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (access === ACCESS.GUEST && isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (requiredRoles) {
+    const hasCorrectRole = TokenService.getUser()?.roles?.some((role) =>
+      requiredRoles.includes(role)
+    );
+    if (!hasCorrectRole) {
+      return <Navigate to="/" replace />;
+    }
+  }
 
   if (!isSupportedScreenSize) {
     return <UnsupportedView />;


### PR DESCRIPTION
## Card: [Link](https://trello.com/c/EAzeZwjG/157-react-survey-editor-url-opened-in-incognito-shows-blank-white-page)
## Summary
- Survey editor URLs (`/design-survey/:id`, `/edit-survey/:id`, `/responses/:id`) and user-management routes (`/users`, `/create-survey`) rendered a blank white page when opened without a session (e.g. pasting a link in incognito) instead of redirecting to `/login`.
- Root cause: in `PrivateDesignSurvey` the `ManagePageWrapper` → `Header` → `SurveyHeader` chain rendered as a sibling of the guard and dereferenced `TokenService.getUser().roles` before `<Navigate>` could take effect, throwing `TypeError: Cannot read properties of undefined (reading 'roles')`. `PrivateManageUsers` had the equivalent bug: `user.roles.forEach` ran before the `isAuthenticated()` check at the end of the function.
- Fix: check `isAuthenticated()` first and short-circuit with `<Navigate to="/login">` (preserving `location.state.from`). `ManagePageWrapper` now mounts inside the guard and only for authenticated users. Role helpers in `constants/roles.js` (`isSurveyAdmin`, `isSuperAdmin`, `isSurveyorOnly`) are now null-safe as defense in depth.

## Test plan
- [ ] With an authenticated session, open `/design-survey/<id>`, `/edit-survey/<id>`, `/responses/<id>` — survey header, side tabs, and content render as before.
- [ ] In an incognito window, paste each of those URLs — browser redirects immediately to `/login` with no blank flash and no console errors.
- [ ] Log in from the incognito window — returned to the originally-requested editor page (via `location.state.from`).
- [ ] In incognito, paste `/users` and `/create-survey` — both redirect to `/login` instead of rendering blank.
- [ ] Console shows no `TypeError: Cannot read properties of undefined (reading 'roles')` during any of the unauthenticated flows.
- [ ] As a non-super-admin authenticated user, `/users` still redirects to `/` (role-gating preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)