### PR TITLE
fix: hide option settings on text choices in translation mode

### DIFF
--- a/src/components/Questions/Choice/ChoiceItemDesign.jsx
+++ b/src/components/Questions/Choice/ChoiceItemDesign.jsx
@@ -251,7 +251,7 @@ function ChoiceItemDesign(props) {
                 : mainContent || props.t("content_editor_placeholder_option")
             }
             InputProps={{
-              endAdornment: (
+              endAdornment: inDesign(props.designMode) ? (
                 <BuildIcon
                   key="setup"
                   color="action"
@@ -268,7 +268,7 @@ function ChoiceItemDesign(props) {
                     );
                   }}
                 />
-              ),
+              ) : undefined,
             }}
           />
         ) : (
@@ -303,23 +303,27 @@ function ChoiceItemDesign(props) {
             />
           </>
         )}
-        <span style={{ margin: "8px" }} />
-        <BuildIcon
-          key="setup"
-          color="action"
-          sx={{ fontSize: 18 }}
-          className={styles.answerIconSettings}
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            dispatch(
-              setup({
-                code: props.qualifiedCode,
-                rules: setupOptions("options"),
-              })
-            );
-          }}
-        />
+        {inDesign(props.designMode) && (
+          <>
+            <span style={{ margin: "8px" }} />
+            <BuildIcon
+              key="setup"
+              color="action"
+              sx={{ fontSize: 18 }}
+              className={styles.answerIconSettings}
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                dispatch(
+                  setup({
+                    code: props.qualifiedCode,
+                    rules: setupOptions("options"),
+                  })
+                );
+              }}
+            />
+          </>
+        )}
         {inDesign(props.designMode) && (
           <CloseIcon
             key="close"


### PR DESCRIPTION
## Summary
- Text MCQ/SCQ choices rendered the build (settings) icon in translation mode, letting users open the option-level setup panel (`Element code` / `Disabled` / `Show when` / Advanced tab) on an option (e.g. `Q3A1`) while translating — none of those rules are translation-relevant.
- Icon-choice and image-choice already gate their action clusters behind `inDesign(designMode)`; applied the same guard to `ChoiceItemDesign.jsx` so the main build icon, its leading spacer, and the `endAdornment` build icon on "other" text options all hide outside design mode.
- No state or routing changes — `setDesignModeToLang` already resets in-progress setup to the language panel; this fix just removes the path to re-open option setup from the item itself.

Trello: https://trello.com/c/QJ2pBzfr/172-option-settings-in-translations

## Test plan
- [ ] In design mode, confirm the build icon on each text option still appears and opens the "Setup for QxAy" panel with Element code / Disabled / Show when / Advanced tab (no regression).
- [ ] Switch to Languages mode via the side tab; confirm the build icon and close icon are both hidden on text options, leaving just the editable label.
- [ ] Confirm the `ManageLanguages` panel remains active on the left — option setup is not reachable while translating.
- [ ] For an "other"-type option, confirm the inline TextField has no trailing build adornment in translation mode.
- [ ] Switch back to design mode — icons reappear and clicking build still opens the option setup.
- [ ] Smoke-test icon-choice and image-choice to confirm their already-gated buttons are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)