### PR TITLE
fix: settings sections expand together due to duplicate accordion ids

### DIFF
--- a/src/pages/manage/EditSurvey/index.jsx
+++ b/src/pages/manage/EditSurvey/index.jsx
@@ -75,6 +75,7 @@ function EditSurvey({ onPublish }) {
       <Box
         display="flex"
         flexWrap={{ xs: "wrap", sm: "wrap", md: "nowrap" }}
+        alignItems="flex-start"
         gap={4}
         width="100%"
       >

--- a/src/pages/manage/EditSurvey/index.jsx
+++ b/src/pages/manage/EditSurvey/index.jsx
@@ -58,14 +58,17 @@ function EditSurvey({ onPublish }) {
       <Accordion className={styles.accordionContainer} defaultExpanded={true}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1a-content"
-          id="panel1a-header"
+          aria-controls="panel-launch-content"
+          id="panel-launch-header"
         >
           <Typography fontWeight="600" color="#1a2052" variant="h5">
             {t("edit_survey.launch")}
           </Typography>
         </AccordionSummary>
-        <AccordionDetails className={styles.accordionDetails}>
+        <AccordionDetails
+          id="panel-launch-content"
+          className={styles.accordionDetails}
+        >
           <LaunchPage onPublish={onPublish} />
         </AccordionDetails>
       </Accordion>
@@ -84,8 +87,8 @@ function EditSurvey({ onPublish }) {
             >
               <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
-                aria-controls="panel1a-content"
-                id="panel1a-header"
+                aria-controls={`panel-${section.id}-content`}
+                id={`panel-${section.id}-header`}
               >
                 <Box display="flex" alignItems="center" gap=".5rem">
                   {section.tooltip && (
@@ -96,7 +99,10 @@ function EditSurvey({ onPublish }) {
                   </Typography>
                 </Box>
               </AccordionSummary>
-              <AccordionDetails className={styles.accordionDetails}>
+              <AccordionDetails
+                id={`panel-${section.id}-content`}
+                className={styles.accordionDetails}
+              >
                 {section.component}
               </AccordionDetails>
             </Accordion>
@@ -113,14 +119,17 @@ function EditSurvey({ onPublish }) {
           >
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
-              aria-controls="panel1a-content"
-              id="panel1a-header"
+              aria-controls={`panel-${section.id}-content`}
+              id={`panel-${section.id}-header`}
             >
               <Typography fontWeight="600" color="#1a2052" variant="h5">
                 {section.title}
               </Typography>
             </AccordionSummary>
-            <AccordionDetails className={styles.accordionDetails}>
+            <AccordionDetails
+              id={`panel-${section.id}-content`}
+              className={styles.accordionDetails}
+            >
               {section.component}
             </AccordionDetails>
           </Accordion>


### PR DESCRIPTION
## Card: [Link](https://trello.com/c/30qE9eiW/186-react-expanding-one-accordion-section-sets-multiple-sections-to-expanded-state-but-displays-content-for-only-one)
## Summary
- Every `AccordionSummary` / `AccordionDetails` in `EditSurvey` was rendered with the same hardcoded `id="panel1a-header"` and `aria-controls="panel1a-content"`. Duplicate DOM ids caused MUI/browser a11y wiring to associate arrow-rotation state across unrelated sections — e.g. expanding **Offline** also flipped **Privacy**'s arrow while leaving its content empty until clicked again.
- Fix: derive unique ids from each section's existing `id` (`panel-launch-*`, `panel-offline-*`, `panel-privacy-*`, `panel-navigation-*`, `panel-quotas-*`, `panel-export-*`) and add a matching `id` on each `AccordionDetails` so the aria relationship is valid end-to-end. No behavior change to the expand model (sections remain independently toggleable).

- Added for fix for better ux
## before
<img width="905" height="275" alt="Screenshot 2026-04-22 at 1 09 34 AM copy" src="https://github.com/user-attachments/assets/64d8f1a2-83ee-4dfe-bf91-63656ee752b3" />

## after
<img width="915" height="290" alt="Screenshot 2026-04-22 at 1 09 17 AM" src="https://github.com/user-attachments/assets/0ecf3d7e-8b59-452d-98eb-d90cbb8d4349" />

## Test plan
- [ ] `npm start` and open the Settings page for any survey.
- [ ] Collapse **Offline** and **Privacy**, then click **Offline**'s arrow — only Offline's arrow rotates and only Offline's content is shown; Privacy stays collapsed.
- [ ] Click **Privacy** — expands independently with no effect on Offline.
- [ ] Repeat with **Navigation / Quotas / Export** and the **Launch** section in various combinations; no cross-section visual side effects.
- [ ] Inspect the DOM: each accordion has a unique `id` on its summary and a matching `id` on its details, with no duplicates on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)