### PR TITLE
fix: render end_page_empty_hint translation instead of raw key

### DIFF
--- a/src/components/design/ContentPanel/index.jsx
+++ b/src/components/design/ContentPanel/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import styles from "./ContentPanel.module.css";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
@@ -25,8 +25,8 @@ function ContentPanel({ designMode }, ref) {
     }
   }, [lang, i18n]);
 
-  const t = useCallback(
-    (key, options) => i18n.getFixedT(lang, NAMESPACES.DESIGN_CORE)(key, options),
+  const t = useMemo(
+    () => i18n.getFixedT(lang, NAMESPACES.DESIGN_CORE),
     [lang, i18n, langReady]
   );
 


### PR DESCRIPTION
## Card: [Link](https://trello.com/c/emi6RKbd/214-empty-thanks-text-in-design-screen)
## Summary
- Empty Thank You Page in the design editor was showing the raw i18n key `end_page_empty_hint` instead of its translated hint text.
- Root cause: `ContentPanel`'s `useCallback` wrapper around `i18n.getFixedT` dropped the `.ns` / `.lng` properties. `<Trans>` reads `t.ns`, saw `undefined`, and fell back to the default `manage` namespace — where `design/core` keys don't resolve.
- Fix: return `i18n.getFixedT(lang, NAMESPACES.DESIGN_CORE)` directly via `useMemo` so `.ns` and `.lng` propagate to `<Trans>`. Direct `t(key)` call sites are unaffected.
<img width="569" height="436" alt="image" src="https://github.com/user-attachments/assets/42889808-286d-4b7e-9343-9b223cd28355" />

## Test plan
- [ ] Open a survey in design mode, navigate to the Thank You Page while it is empty, and confirm the hint renders as "This page **can only** contain Info Questions (Text, Image or Video Display)" with `can only` bolded — not the raw `end_page_empty_hint` key.
- [ ] Switch survey language to Arabic and re-check the hint renders the Arabic translation.
- [ ] Regression: "Drop question here", `empty_group_hint`, and `empty_group_hint_last` still render correctly on regular pages.
- [ ] Regression: `wrong_logic_err` (other `<Trans>` in `design/core`) still renders with its `<strong>` markup in the relevance panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)