### PR TITLE
refactor: apply serverDateTimeToLocalDateTime to event timestamps

### DIFF
--- a/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
+++ b/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
@@ -247,36 +247,30 @@ function ResponsesList() {
   const formatEventTime = (time) => {
     if (!time) return "—";
 
+    let date = null;
+
     // Handle array format: [year, month, day, hour, minute, second]
     if (Array.isArray(time) && time.length >= 6) {
-      return formatlocalDateTime(
-        new Date(time[0], time[1] - 1, time[2], time[3], time[4], time[5]),
-      );
+      date = new Date(time[0], time[1] - 1, time[2], time[3], time[4], time[5]);
     }
-
     // Handle object format (Java LocalDateTime serialization)
-    if (typeof time === "object" && time.year !== undefined) {
-      return formatlocalDateTime(
-        new Date(
-          time.year,
-          (time.monthValue || time.month) - 1,
-          time.dayOfMonth || time.day,
-          time.hour || 0,
-          time.minute || 0,
-          time.second || 0,
-        ),
+    else if (typeof time === "object" && time.year !== undefined) {
+      date = new Date(
+        time.year,
+        (time.monthValue || time.month) - 1,
+        time.dayOfMonth || time.day,
+        time.hour || 0,
+        time.minute || 0,
+        time.second || 0,
       );
     }
-
     // Handle ISO string format
-    if (typeof time === "string") {
-      const date = new Date(time);
-      if (!isNaN(date.getTime())) {
-        return formatlocalDateTime(date);
-      }
+    else if (typeof time === "string") {
+      date = new Date(time);
     }
 
-    return "—";
+    if (!date || isNaN(date.getTime())) return "—";
+    return formatlocalDateTime(serverDateTimeToLocalDateTime(date));
   };
 
   const renderVoiceRecordings = (respId, events) => {


### PR DESCRIPTION
## Card: [Link](https://trello.com/c/HfHomPE6/145-voice-recording-timestamps-are-offset-by-2-hours-compared-to-response-start-time)
<img width="816" height="564" alt="image" src="https://github.com/user-attachments/assets/a11c6d15-b80e-46f0-b0f5-1bba1babe7f8" />


## Summary
- Route `formatEventTime` through `serverDateTimeToLocalDateTime` so event-log and location timestamps in `ResponsesList` use the same timezone handling as `startDate`/`submitDate`.
- Collapse the three return branches into a single parse-then-format path for the array, Java `LocalDateTime` object, and ISO string inputs.

## Test plan
- [ ] Open a response in Manage → Responses and confirm the Events column and Locations field render times consistent with the response's Start/Submit dates.
- [ ] Verify all three `time` payload shapes still render (array, object, ISO string) and that invalid/missing values fall back to `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)