### PR TITLE
fix: hide save button in offline preview mode

### DIFF
--- a/src/components/run/SurveyAppBar/index.jsx
+++ b/src/components/run/SurveyAppBar/index.jsx
@@ -40,6 +40,10 @@ function SurveyAppBar({ toggleDrawer, preview }) {
     return state.runState.data.navigationData.allowIncomplete;
   }, shallowEqual);
 
+  const mode = useSelector((state) => {
+    return state.runState.values.Survey.mode;
+  });
+
   const theme = useTheme();
 
   const [saveOpen, setSaveOpen] = useState(false);
@@ -102,7 +106,7 @@ function SurveyAppBar({ toggleDrawer, preview }) {
           <MenuIcon />
         </IconButton>
         <Box display="flex" gap={2}>
-          {!isAndroid && canSave && (
+          {!isAndroid && canSave && !(preview && mode == "offline") && (
             <Button
               variant="contained"
               size="small"


### PR DESCRIPTION
## Card: https://trello.com/c/RWdhlsCP/217-hide-save-button-in-preview-offline-mode
<img width="546" height="708" alt="image" src="https://github.com/user-attachments/assets/db3fc428-7b81-4976-9a12-91aa506a7958" />

## Summary
- Hide the SAVE button in the survey app bar when previewing in offline mode, where the web save flow doesn't apply (the Android app handles local saving).
- Reuses the existing `preview && mode == "offline"` gating pattern already used in Barcode/PhotoCapture/VideoCapture.

## Test plan
- [ ] `npm start` and open a survey preview.
- [ ] Desktop tab: SAVE appears (when `allowIncomplete` is true).
- [ ] Phone tab: SAVE appears.
- [ ] Offline tab: SAVE is hidden.
- [ ] Switch back to desktop/phone: SAVE reappears.
- [ ] Normal (non-preview) runner: SAVE behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)