### PR TITLE
refactor: convert create survey from inline bar to modal

### DIFF
--- a/src/components/manage/CreateSurvey/CreateSurvey.jsx
+++ b/src/components/manage/CreateSurvey/CreateSurvey.jsx
@@ -1,11 +1,11 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
-import { Box, Card } from "@mui/material";
+import { Box, Button, IconButton, Modal, Typography } from "@mui/material";
+import { Close } from "@mui/icons-material";
 import * as Yup from "yup";
 import { PROCESSED_ERRORS } from "~/utils/errorsProcessor";
 import styles from "./CreateSurvey.module.css";
-import { localDateToServerDateTime } from "~/utils/DateUtils";
 import { SURVEY_MODE } from "~/constants/survey";
 import { setLoading } from "~/state/edit/editState";
 import { useDispatch } from "react-redux";
@@ -21,7 +21,8 @@ const surveyMode_options = [
   { value: SURVEY_MODE.OFFLINE, label: `mode.${SURVEY_MODE.OFFLINE}` },
   { value: SURVEY_MODE.MIXED, label: `mode.${SURVEY_MODE.MIXED}` },
 ];
-function CreateSurvey({ onSurveyCreated }) {
+
+function CreateSurvey({ open, onResult }) {
   const surveyService = useService("survey");
   const navigate = useNavigate();
 
@@ -31,9 +32,8 @@ function CreateSurvey({ onSurveyCreated }) {
   const defaultValues = {
     surveyName: "",
     surveyMode: SURVEY_MODE.MIXED,
-    surveyActiveFrom: "",
-    surveyActiveTo: "",
   };
+
   const CreateSurveySchema = useMemo(
     () =>
       Yup.object().shape({
@@ -43,6 +43,7 @@ function CreateSurvey({ onSurveyCreated }) {
       }),
     [t]
   );
+
   const methods = useForm({
     resolver: yupResolver(CreateSurveySchema),
     defaultValues,
@@ -55,6 +56,12 @@ function CreateSurvey({ onSurveyCreated }) {
     formState: { isSubmitting },
   } = methods;
 
+  useEffect(() => {
+    if (open) {
+      reset(defaultValues);
+    }
+  }, [open]);
+
   const onSubmit = handleSubmit(async (data) => {
     dispatch(setLoading(true));
     const model = {
@@ -62,17 +69,10 @@ function CreateSurvey({ onSurveyCreated }) {
       usage: data.surveyMode,
     };
 
-    if (data.surveyActiveFrom) {
-      model.startDate = localDateToServerDateTime(surveyActiveFrom);
-    }
-
-    if (data.surveyActiveTo) {
-      model.endDate = localDateToServerDateTime(surveyActiveTo);
-    }
-
     surveyService
       .createSurvey(model)
       .then((res) => {
+        onResult(true);
         navigate("/design-survey/" + res.id);
       })
       .catch((processedError) => {
@@ -83,51 +83,84 @@ function CreateSurvey({ onSurveyCreated }) {
             type: "manual",
             message: t(`processed_errors.${processedError.name}`),
           });
-        } else if (
-          processedError.name == PROCESSED_ERRORS.INVALID_SURVEY_DATES.name
-        ) {
-          setError("surveyActiveFrom", {
-            type: "manual",
-            message: t(`processed_errors.${processedError.name}`),
-          });
         }
       })
       .finally(() => {
         dispatch(setLoading(false));
       });
   });
+
   return (
-    <Card className={styles.createUserCard}>
-      <FormProvider methods={methods} onSubmit={onSubmit}>
+    <Modal
+      sx={{
+        ".MuiBackdrop-root": {
+          backgroundColor: "rgba(0, 0, 0, 0.3)",
+        },
+      }}
+      open={open}
+      onClose={(event, reason) => {
+        if (reason === "backdropClick" || reason === "escapeKeyDown") {
+          onResult(false);
+        }
+      }}
+      closeAfterTransition
+      disableEscapeKeyDown={false}
+    >
+      <Box className={styles.wrapper}>
         <Box
-          rowGap={2.5}
-          columnGap={2}
-          display="grid"
-          gridTemplateColumns={{ xs: "repeat(1, 1fr)", md: "repeat(3, 1fr)" }}
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+          }}
         >
-          <RHFTextField name="surveyName" label={t("label.survey_name")} />
-
-          <RHFSelect name="surveyMode" label={t("label.survey_mode")}>
-            {surveyMode_options.map((option) => (
-              <option key={option.value} value={option.value}>
-                {t(option.label)}
-              </option>
-            ))}
-          </RHFSelect>
-
-          <LoadingButton
-            fullWidth
-            size="large"
-            color="primary"
-            type="submit"
-            variant="contained"
-            loading={isSubmitting}
+          <Typography fontWeight={600} variant="h5">
+            {t("create_new_survey")}
+          </Typography>
+          <IconButton
+            onClick={() => onResult(false)}
+            sx={{
+              color: "text.secondary",
+              "&:hover": {
+                backgroundColor: "rgba(0, 0, 0, 0.04)",
+              },
+            }}
+            aria-label="close"
           >
-            {t("action_btn.create")}
-          </LoadingButton>
+            <Close />
+          </IconButton>
         </Box>
-      </FormProvider>
-    </Card>
+
+        <FormProvider methods={methods} onSubmit={onSubmit}>
+          <Box display="flex" flexDirection="column" gap={2}>
+            <RHFTextField name="surveyName" label={t("label.survey_name")} />
+
+            <RHFSelect name="surveyMode" label={t("label.survey_mode")}>
+              {surveyMode_options.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {t(option.label)}
+                </option>
+              ))}
+            </RHFSelect>
+          </Box>
+
+          <Box className={styles.footer}>
+            <Button onClick={() => onResult(false)} color="inherit">
+              {t("action_btn.cancel")}
+            </Button>
+            <LoadingButton
+              type="submit"
+              variant="contained"
+              color="primary"
+              loading={isSubmitting}
+            >
+              {t("action_btn.create")}
+            </LoadingButton>
+          </Box>
+        </FormProvider>
+      </Box>
+    </Modal>
   );
 }
 

--- a/src/components/manage/CreateSurvey/CreateSurvey.module.css
+++ b/src/components/manage/CreateSurvey/CreateSurvey.module.css
@@ -1,66 +1,18 @@
-.createUserCard.createUserCard {
-  padding: 2rem;
-  border-radius: 20px;
-  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
-    rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
-
+.wrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #ffffff;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 20px;
+  min-width: 500px;
 }
 
-.formGroup.formGroup {
+.footer {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  gap: 2rem;
-}
-.rightContainer.rightContainer {
-  display: flex;
-  flex-direction: row;
-  gap: 2.5rem;
-  flex: auto;
   justify-content: flex-end;
-}
-
-.createButton.createButton {
-  text-transform: none;
-  color: white;
-  padding: 0.75rem 7rem;
-  background-color: #04bdf3;
-  border-radius: 20px;
-  height: fit-content;
-  transition: background-color 0.3s ease, color 0.3s ease, border 0.3s ease;
-}
-.createButton.createButton:hover {
-  border: 1px solid #04bdf3;
-  color: #04bdf3;
-  background-color: #fff;
-}
-
-.surveyNameInput {
-  padding-left: 14px;
-}
-
-@media only screen and (max-width: 768px) {
-  .createUserCard.createUserCard {
-    padding: 1rem;
-  }
-  .formGroup.formGroup {
-    flex-direction: column;
-  }
-  .rightContainer.rightContainer {
-    width: 100%;
-    flex-direction: column;
-    gap: 2rem;
-  }
-  .selectInput {
-    width: 100% !important;
-  }
-  .surveyNameInput.surveyNameInput {
-    width: 100%;
-  }
-}
-
-.errorText {
-  color: #eb5757 !important;
-  padding-left: 14px;
+  gap: 8px;
+  margin-top: 24px;
 }

--- a/src/pages/manage/Dashboard/index.jsx
+++ b/src/pages/manage/Dashboard/index.jsx
@@ -1,11 +1,9 @@
-import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
+import React, { lazy, Suspense, useEffect, useState } from "react";
 import {
   Alert,
   Box,
   Button,
   Container,
-  Fade,
-  IconButton,
   Snackbar,
   Stack,
   TablePagination,
@@ -28,8 +26,7 @@ import LoadingDots from "~/components/common/LoadingDots";
 import { useService } from "~/hooks/use-service";
 import DeleteModal from "~/components/common/DeleteModal";
 import StopSurveyModal from "~/components/manage/StopSurveyModal";
-import { Add, Close, Description, FileUpload } from "@mui/icons-material";
-import { getDirFromSession } from "~/utils/common";
+import { Add, Description, FileUpload } from "@mui/icons-material";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import DashboardEmptyState from "~/components/manage/DashboardEmptyState";
 import {
@@ -76,7 +73,6 @@ function Dashboard() {
         if (data) {
           setFetchingSurveys(false);
           setSurveys(data);
-          setCreateSurveyOpen(false);
         }
       })
       .catch((e) => processApirror(e));
@@ -105,36 +101,14 @@ function Dashboard() {
   const [selectedSurvey, setSelectedSurvey] = useState(null);
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState(t("action_btn.delete"));
-  const [isCreateSurveyOpen, setCreateSurveyOpen] = useState(false);
-  const [importSurvey, setImportSurvey] = useState(false);
-  const mainContainerRef = useRef(null);
+  const [openCreateModal, setOpenCreateModal] = useState(false);
 
-  const scrollToTop = () => {
-    if (mainContainerRef.current) {
-      mainContainerRef.current.scrollTo({ top: 0, behavior: "smooth" });
-    }
+  const handleCreateSurveyClick = () => {
+    setOpenCreateModal(true);
   };
-
-  const handleButtonClick = () => {
-    if (isCreateSurveyOpen) {
-      scrollToTop();
-    } else {
-      setCreateSurveyOpen(true);
-    }
-  };
-
-  useEffect(() => {
-    if (isCreateSurveyOpen) {
-      scrollToTop();
-    }
-  }, [isCreateSurveyOpen]);
 
   const handleImportSurveyClick = () => {
     setOpenImportModal(true);
-  };
-
-  const handleCloseClick = () => {
-    setCreateSurveyOpen(false);
   };
 
   const onDelete = (survey) => {
@@ -277,10 +251,8 @@ function Dashboard() {
     });
   };
 
-  const isRtl = getDirFromSession();
-
   return (
-    <Box ref={mainContainerRef} className={styles.mainContainer}>
+    <Box className={styles.mainContainer}>
       <Container sx={{ marginBottom: "48px" }}>
         <Box className={styles.content}>
           {(surveys?.surveys?.length > 0 || status !== "all") && (
@@ -289,7 +261,7 @@ function Dashboard() {
             direction="row"
             spacing={2}
           >
-            {isSurveyAdmin() && !isCreateSurveyOpen && (
+            {isSurveyAdmin() && (
               <CustomTooltip
                 title={t("tooltips.create_new_survey")}
                 showIcon={false}
@@ -298,7 +270,7 @@ function Dashboard() {
                   variant="contained"
                   color="primary"
                   startIcon={<Add />}
-                  onClick={handleButtonClick}
+                  onClick={handleCreateSurveyClick}
                 >
                   {t("create_new_survey")}
                 </Button>
@@ -320,27 +292,6 @@ function Dashboard() {
               </CustomTooltip>
             )}
           </Stack>
-          )}
-
-          {isCreateSurveyOpen && (
-            <Fade in={isCreateSurveyOpen} timeout={300}>
-              <div style={{ position: "relative" }}>
-                <IconButton
-                  onClick={handleCloseClick}
-                  aria-label="close"
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    ...(isRtl === "ltr" ? { right: 0 } : { left: 0 }),
-                    color: "black",
-                    zIndex: 1,
-                  }}
-                >
-                  <Close color="#000" />
-                </IconButton>
-                <CreateSurvey />
-              </div>
-            </Fade>
           )}
 
           {(surveys?.surveys?.length > 0 || status != "all") && (
@@ -421,7 +372,7 @@ function Dashboard() {
                   </div>
                 ) : (
                   <DashboardEmptyState
-                    onCreateSurvey={handleButtonClick}
+                    onCreateSurvey={handleCreateSurveyClick}
                     onImportTemplate={handleImportSurveyClick}
                     canCreate={isSurveyAdmin()}
                   />
@@ -460,6 +411,15 @@ function Dashboard() {
         open={openImportModal}
         onResult={(success) => {
           setOpenImportModal(false);
+          if (success) {
+            fetchSurveys();
+          }
+        }}
+      />
+      <CreateSurvey
+        open={openCreateModal}
+        onResult={(success) => {
+          setOpenCreateModal(false);
           if (success) {
             fetchSurveys();
           }


### PR DESCRIPTION
## Summary
- Convert the **Create New Survey** action from an inline `<Card>` form that pushed dashboard content down to an MUI `Modal` overlay that mirrors the existing **Import Survey** modal.
- New `CreateSurvey` component API: `({ open, onResult })`, matching `ImportSurvey`. Header with title + close icon, vertically-stacked `RHFTextField` (name) and `RHFSelect` (mode), right-aligned `Cancel` / `Create` footer. Form resets on each open.
- Dashboard now renders `<CreateSurvey>` as a sibling of `<ImportSurvey>` at the bottom of the page tree. Removed inline render block, `scrollToTop`, `mainContainerRef`, the conditional button-hiding when the form was open, and the now-unused `Fade` / `IconButton` / `Close` / `useRef` / `getDirFromSession` imports.
- Dropped the unreachable date-handling block from the submit handler (form never rendered date inputs, and the code referenced undeclared identifiers).

## Test plan
- [ ] Click **Create New Survey** → modal opens centered over the dashboard.
- [ ] Fill name + mode → **Create** → navigates to `/design-survey/{id}`.
- [ ] Cancel paths: X icon, footer **Cancel**, Escape, backdrop click — all close the modal without navigating.
- [ ] Empty name → Yup validation error inline.
- [ ] Duplicate name → `DUPLICATE_SURVEY_NAME` error rendered under the `surveyName` field.
- [ ] Empty-state CTA (filter to a status with zero surveys) opens the modal.
- [ ] Reopen freshness: type a name, close without submitting, reopen → fields reset.
- [ ] **Import Survey** modal still works unchanged.
- [ ] RTL (Arabic): modal header alignment and close button render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)