### PR TITLE
fix: dismissed product tours reappear after dismiss

### DIFF
--- a/src/hooks/useIntroTour.js
+++ b/src/hooks/useIntroTour.js
@@ -10,7 +10,6 @@ import {
   mirrorPositionForRtl,
   positionSkipButtonAwayFromArrow,
   readTourProgress,
-  saveTourStep,
   setNextButtonText,
   setPrevButtonText,
 } from "~/utils/tour";
@@ -28,12 +27,15 @@ export function useIntroTour({
   onExitExtra,
 }) {
   const introInstanceRef = useRef(null);
+  const isProgrammaticExitRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) return undefined;
 
     const { completed, startStep } = readTourProgress(storageKey);
     if (completed) return undefined;
+
+    isProgrammaticExitRef.current = false;
 
     const rtl = isSessionRtl();
     const tourSteps = getSteps();
@@ -96,19 +98,18 @@ export function useIntroTour({
         }, 0);
       });
 
-      intro.onComplete(function (currentStep, reason) {
-        if (reason === "done") {
-          markTourCompleted(storageKey);
-        } else {
-          saveTourStep(storageKey, currentStep ?? 0);
-        }
+      intro.onComplete(function () {
+        markTourCompleted(storageKey);
       });
 
       intro.onExit(function () {
-        const stepIndex = this.getCurrentStep();
-        saveTourStep(storageKey, stepIndex ?? 0);
         clearHighlightedElementClasses();
         onExitExtra?.();
+        if (isProgrammaticExitRef.current) {
+          isProgrammaticExitRef.current = false;
+          return;
+        }
+        markTourCompleted(storageKey);
       });
 
       intro.start();
@@ -119,7 +120,10 @@ export function useIntroTour({
 
     return () => {
       clearTimeout(timer);
-      introInstanceRef.current?.exit(true);
+      if (introInstanceRef.current) {
+        isProgrammaticExitRef.current = true;
+        introInstanceRef.current.exit(true);
+      }
       onExitExtra?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- User-initiated tour exits (× skip button, "Remind Me Later", Esc) now persist as completed, so dismissing the DesignTour or PreviewSurveyTour actually keeps it dismissed.
- Previously `onExit` only saved the current step number; combined with DesignTour's `deps: [designState]`, any subsequent state mutation would re-mount the effect, read progress as incomplete, and re-show the tour right after dismiss.
- React cleanup-driven exits (deps change / unmount) are now guarded with a ref flag so they do not mark the tour completed prematurely.
- `onComplete` simplified to unconditionally mark completed; unused `saveTourStep` import removed.

## Test plan
- [ ] Clear `localStorage.design_tour_completed`, open an empty-design survey, wait for tour, click **Remind Me Later** → tour stays dismissed across `designState` edits and a page reload; `localStorage.design_tour_completed === "true"`.
- [ ] Repeat the above and dismiss via the **×** skip button on step 2 or 3 → same expected outcome.
- [ ] Repeat the above and dismiss via **Esc** → same expected outcome.
- [ ] Clear the storage key, click through every step to **Done** → tour stays dismissed on reload.
- [ ] PreviewSurveyTour: dismiss via × and via Esc in separate runs → tour stays dismissed on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)