### PR TITLE
feat: add preview end-page action buttons

### DIFF
--- a/public/locales/ar/run.json
+++ b/public/locales/ar/run.json
@@ -53,5 +53,11 @@
   "saveAndContinueLaterDesc": "سنحفظ تقدمك الحالي. يمكنك العودة إلى هذا الاستبيان لاحقًا.",
   "saveForLater": "احفظ لوقت لاحق",
   "linkCopied": "تم نسخ الرابط إلى الحافظة!",
-  "no_options": "لا توجد خيارات"
+  "no_options": "لا توجد خيارات",
+  "preview_end_actions": {
+    "heading": "خيارات المعاينة",
+    "check_response": "عرض الرد",
+    "reset": "إعادة تعيين المعاينة",
+    "close_window": "إغلاق النافذة"
+  }
 }

--- a/public/locales/de/run.json
+++ b/public/locales/de/run.json
@@ -53,5 +53,11 @@
   "saveAndContinueLaterDesc": "Wir speichern deinen aktuellen Fortschritt. Du kannst später zu dieser Umfrage zurückkehren.",
   "saveForLater": "Für später speichern",
   "linkCopied": "Link in die Zwischenablage kopiert!",
-  "no_options": "Keine Optionen gefunden"
+  "no_options": "Keine Optionen gefunden",
+  "preview_end_actions": {
+    "heading": "Vorschauoptionen",
+    "check_response": "Antwort prüfen",
+    "reset": "Vorschau zurücksetzen",
+    "close_window": "Fenster schließen"
+  }
 }

--- a/public/locales/en/run.json
+++ b/public/locales/en/run.json
@@ -53,5 +53,11 @@
     "saveAndContinueLaterDesc":"We’ll save your current progress. You can return to this survey later.",
     "saveForLater":"Save for later",
     "linkCopied":"Link copied to clipboard!",
-    "no_options": "No options found"
+    "no_options": "No options found",
+    "preview_end_actions": {
+        "heading": "Preview options",
+        "check_response": "Check response",
+        "reset": "Reset preview",
+        "close_window": "Close window"
+    }
 }

--- a/public/locales/es/run.json
+++ b/public/locales/es/run.json
@@ -53,6 +53,12 @@
     "saveAndContinueLaterDesc":"Guardaremos tu progreso actual. Puedes regresar a esta encuesta más tarde.",
     "saveForLater":"Guardar para más tarde",
     "linkCopied":"¡Enlace copiado al portapapeles!",
-    "no_options": "No se encontraron opciones"
+    "no_options": "No se encontraron opciones",
+    "preview_end_actions": {
+        "heading": "Opciones de vista previa",
+        "check_response": "Ver respuesta",
+        "reset": "Reiniciar vista previa",
+        "close_window": "Cerrar ventana"
+    }
 }
 

--- a/public/locales/fr/run.json
+++ b/public/locales/fr/run.json
@@ -53,5 +53,11 @@
     "saveAndContinueLaterDesc":"Nous enregistrerons votre progression actuelle. Vous pouvez revenir à ce sondage plus tard.",
     "saveForLater":"Enregistrer pour plus tard",
     "linkCopied":"Lien copié dans le presse-papiers !",
-    "no_options": "Aucune option trouvée"
+    "no_options": "Aucune option trouvée",
+    "preview_end_actions": {
+        "heading": "Options d'aperçu",
+        "check_response": "Voir la réponse",
+        "reset": "Réinitialiser l'aperçu",
+        "close_window": "Fermer la fenêtre"
+    }
 }

--- a/public/locales/nl/run.json
+++ b/public/locales/nl/run.json
@@ -53,5 +53,11 @@
     "saveAndContinueLaterDesc":"We slaan je huidige voortgang op. Je kunt later terugkeren naar deze enquête.",
     "saveForLater":"Opslaan voor later",
     "linkCopied":"Link gekopieerd naar klembord!",
-    "no_options": "Geen opties gevonden"
+    "no_options": "Geen opties gevonden",
+    "preview_end_actions": {
+        "heading": "Voorbeeldopties",
+        "check_response": "Reactie bekijken",
+        "reset": "Voorbeeld opnieuw instellen",
+        "close_window": "Venster sluiten"
+    }
 }

--- a/public/locales/pt/run.json
+++ b/public/locales/pt/run.json
@@ -53,5 +53,11 @@
     "saveAndContinueLaterDesc":"Salvaremos seu progresso atual. Você pode retornar a esta pesquisa mais tarde.",
     "saveForLater":"Salvar para mais tarde",
     "linkCopied":"Link copiado para a área de transferência!",
-    "no_options": "Nenhuma opção encontrada"
+    "no_options": "Nenhuma opção encontrada",
+    "preview_end_actions": {
+        "heading": "Opções de pré-visualização",
+        "check_response": "Ver resposta",
+        "reset": "Redefinir pré-visualização",
+        "close_window": "Fechar janela"
+    }
 }

--- a/src/components/run/PreviewEndActions/index.jsx
+++ b/src/components/run/PreviewEndActions/index.jsx
@@ -64,12 +64,9 @@ const PreviewEndActions = () => {
         <Button
           variant="text"
           size="medium"
+          color="error"
           onClick={() => sendAction("close")}
-          sx={{
-            textTransform: "capitalize",
-            color: "text.secondary",
-            "&:hover": { backgroundColor: "action.hover" },
-          }}
+          sx={{ textTransform: "capitalize" }}
         >
           {t("preview_end_actions.close_window")}
         </Button>

--- a/src/components/run/PreviewEndActions/index.jsx
+++ b/src/components/run/PreviewEndActions/index.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { NAMESPACES } from "~/hooks/useNamespaceLoader";
+
+const PreviewEndActions = () => {
+  const { t } = useTranslation(NAMESPACES.RUN);
+  const responseId = useSelector(
+    (state) => state.runState.data?.responseId
+  );
+
+  const sendAction = (action) => {
+    window.parent.postMessage(
+      { type: "PREVIEW_END_ACTION", action, responseId },
+      window.location.origin
+    );
+  };
+
+  return (
+    <Box
+      sx={{
+        maxWidth: 720,
+        mx: "auto",
+        mt: 3,
+        mb: 4,
+        px: 3,
+        py: 3,
+        textAlign: "center",
+        borderTop: "1px dashed",
+        borderColor: "divider",
+      }}
+    >
+      <Typography
+        variant="overline"
+        sx={{ color: "text.secondary", letterSpacing: 1 }}
+      >
+        {t("preview_end_actions.heading")}
+      </Typography>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={1.5}
+        mt={1.5}
+        justifyContent="center"
+        alignItems="center"
+        flexWrap="wrap"
+      >
+        <Button
+          variant="contained"
+          size="medium"
+          onClick={() => sendAction("check")}
+          sx={{ textTransform: "capitalize" }}
+        >
+          {t("preview_end_actions.check_response")}
+        </Button>
+        <Button
+          variant="outlined"
+          size="medium"
+          onClick={() => sendAction("reset")}
+          sx={{ textTransform: "capitalize" }}
+        >
+          {t("preview_end_actions.reset")}
+        </Button>
+        <Button
+          variant="text"
+          size="medium"
+          onClick={() => sendAction("close")}
+          sx={{
+            textTransform: "capitalize",
+            color: "text.secondary",
+            "&:hover": { backgroundColor: "action.hover" },
+          }}
+        >
+          {t("preview_end_actions.close_window")}
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default PreviewEndActions;

--- a/src/pages/PreviewSurvey/index.jsx
+++ b/src/pages/PreviewSurvey/index.jsx
@@ -69,26 +69,53 @@ function PreviewSurvey({ responseId = null }) {
 
   useEffect(() => {
     const handleMessage = (event) => {
-      // Always verify the origin for security
-      if (
-        event.origin !== window.location.origin ||
-        event.data.type !== "RESPONSE_ID_RECEIVED"
-      ) {
+      if (event.origin !== window.location.origin) {
         return;
       }
 
-      const iFrameResponseId = event.data.responseId;
-      if (currentResponseId != iFrameResponseId) {
-        setCurrentResponseId(iFrameResponseId);
-        window.history.replaceState(
-          {},
-          "",
-          routes.resumePreview
-            .replace(":surveyId", surveyId)
-            .replace(":responseId", iFrameResponseId)
-        );
+      if (event.data.type === "RESPONSE_ID_RECEIVED") {
+        const iFrameResponseId = event.data.responseId;
+        if (currentResponseId != iFrameResponseId) {
+          setCurrentResponseId(iFrameResponseId);
+          window.history.replaceState(
+            {},
+            "",
+            routes.resumePreview
+              .replace(":surveyId", surveyId)
+              .replace(":responseId", iFrameResponseId)
+          );
+        }
+        return;
       }
-      // Handle the message data here
+
+      if (event.data.type === "PREVIEW_END_ACTION") {
+        const responseIdFromMsg =
+          event.data.responseId || currentResponseId;
+
+        if (event.data.action === "check") {
+          if (responseIdFromMsg) {
+            sessionStorage.setItem("responseId", responseIdFromMsg);
+          }
+          window.open(
+            routes.responses.replace(":surveyId", surveyId),
+            "_blank",
+            "noopener,noreferrer"
+          );
+          return;
+        }
+
+        if (event.data.action === "reset") {
+          window.location.href =
+            routes.preview.replace(":surveyId", surveyId) +
+            window.location.search;
+          return;
+        }
+
+        if (event.data.action === "close") {
+          // window.close() is silently blocked unless the tab was opened by JS.
+          window.close();
+        }
+      }
     };
 
     window.addEventListener("message", handleMessage);

--- a/src/pages/PreviewSurvey/index.jsx
+++ b/src/pages/PreviewSurvey/index.jsx
@@ -93,14 +93,12 @@ function PreviewSurvey({ responseId = null }) {
           event.data.responseId || currentResponseId;
 
         if (event.data.action === "check") {
-          if (responseIdFromMsg) {
-            sessionStorage.setItem("responseId", responseIdFromMsg);
-          }
-          window.open(
-            routes.responses.replace(":surveyId", surveyId),
-            "_blank",
-            "noopener,noreferrer"
-          );
+          // sessionStorage doesn't cross tabs, so pass responseId via URL.
+          const baseUrl = routes.responses.replace(":surveyId", surveyId);
+          const targetUrl = responseIdFromMsg
+            ? `${baseUrl}?responseId=${encodeURIComponent(responseIdFromMsg)}`
+            : baseUrl;
+          window.open(targetUrl, "_blank", "noopener,noreferrer");
           return;
         }
 

--- a/src/pages/RunSurvey/index.jsx
+++ b/src/pages/RunSurvey/index.jsx
@@ -29,6 +29,7 @@ import RunLoadingDots from "~/components/common/RunLoadingDots";
 
 import SurveyDrawer, { COLLAPSE, EXPAND } from "~/components/run/SurveyDrawer";
 import SurveyAppBar from "~/components/run/SurveyAppBar";
+import PreviewEndActions from "~/components/run/PreviewEndActions";
 import { routes } from "~/routes";
 
 function RunSurvey({
@@ -314,6 +315,7 @@ function RunSurvey({
                 <SurveyMemo
                   key="Survey"
                 />
+                {preview && SURVEY_ENDED && <PreviewEndActions />}
                 <SurveyDrawer
                   expanded={expanded}
                   toggleDrawer={toggleDrawer}

--- a/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
+++ b/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
 import {
@@ -83,6 +83,8 @@ function ResponsesList() {
   const surveyService = useService("survey");
   const { t } = useTranslation(NAMESPACES.MANAGE);
   const { surveyId } = useParams();
+  const [searchParams] = useSearchParams();
+  const urlResponseId = searchParams.get("responseId");
 
   const [fetching, setFetching] = useState(true);
   const [status, setStatus] = useState("all");
@@ -90,9 +92,14 @@ function ResponsesList() {
 
   const [allResponse, setAllResponse] = useState(null);
   const [responseId, setResponseId] = useState(() => {
+    if (urlResponseId) return urlResponseId;
     const stored = sessionStorage.getItem("responseId");
     return stored ? stored : null;
   });
+  // When responseId arrived via URL, the first fetch's "not in current page"
+  // check would clear it before getResponseById can resolve. Skip that clear
+  // exactly once so cross-tab navigation from the preview screen works.
+  const skipNextResponseClearRef = useRef(!!urlResponseId);
   const [selected, setSelected] = useState(null);
   const [activeTab, setActiveTab] = useState(0);
   const [eventsData, setEventsData] = useState(null);
@@ -135,8 +142,12 @@ function ResponsesList() {
           }
           setAllResponse(data);
           if (responseId && !data.responses?.some((r) => r.id === responseId)) {
-            setResponseId(null);
-            setSelected(null);
+            if (skipNextResponseClearRef.current) {
+              skipNextResponseClearRef.current = false;
+            } else {
+              setResponseId(null);
+              setSelected(null);
+            }
           }
         }
         setFetching(false);

--- a/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
+++ b/src/pages/manage/ResponsesSurvey/ResponsesList.jsx
@@ -83,7 +83,7 @@ function ResponsesList() {
   const surveyService = useService("survey");
   const { t } = useTranslation(NAMESPACES.MANAGE);
   const { surveyId } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const urlResponseId = searchParams.get("responseId");
 
   const [fetching, setFetching] = useState(true);
@@ -100,6 +100,13 @@ function ResponsesList() {
   // check would clear it before getResponseById can resolve. Skip that clear
   // exactly once so cross-tab navigation from the preview screen works.
   const skipNextResponseClearRef = useRef(!!urlResponseId);
+  useEffect(() => {
+    if (!urlResponseId) return;
+    const next = new URLSearchParams(searchParams);
+    next.delete("responseId");
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [selected, setSelected] = useState(null);
   const [activeTab, setActiveTab] = useState(0);
   const [eventsData, setEventsData] = useState(null);


### PR DESCRIPTION
## Card
[Trello: Add CTAs to preview page when the user finishes preview](https://trello.com/c/XISbN18O/245-add-ctas-to-preview-page-when-the-user-finishes-preview)

## Recording
https://www.awesomescreenshot.com/video/52729279?key=2cb380b7ae5f8fdc7f67d5c3c2b74433

## Summary
- When a preview survey reaches its end page, three action buttons render inline under the thank-you content: **Check response**, **Reset preview**, **Close window**.
- Buttons live inside the runner iframe and `postMessage` a `PREVIEW_END_ACTION` to the parent `PreviewSurvey`, which executes the actual navigation/window operations (so the parent still owns URL/window state).
- Translations added to all seven supported locales (en, ar, de, es, pt, fr, nl).

## Behavior
- **Check response** — opens `/responses/:surveyId?responseId=<id>` in a new tab. The responses page reads the URL param (sessionStorage doesn't cross tabs) and preselects the response, skipping the first-fetch "not in current page" clear so it stays selected even when not on page 1.
- **Reset preview** — reloads the parent to `/preview/:surveyId` (drops the `:responseId`), preserving `mode` / `navigation_mode` query params. The iframe re-mounts with a fresh response.
- **Close window** — calls `window.close()`. Silently no-ops if the tab wasn't opened by JS (browser blocks).

## Test plan
- [ ] Open a survey's design page → click **Preview**.
- [ ] Walk the preview to its end page in each navigation mode (`ALL_IN_ONE`, `GROUP_BY_GROUP`, `QUESTION_BY_QUESTION`).
- [ ] Confirm the three buttons render in a single row under the thank-you content (column stack on very narrow phone-preview).
- [ ] Click **Check response** → new tab opens at `/responses/:surveyId?responseId=…` with this response preselected and visible in the detail panel.
- [ ] Click **Reset preview** → URL drops the `responseId` segment, page reloads, fresh response begins.
- [ ] Click **Close window** (danger-colored) → tab closes if opened from design page; otherwise no visible effect.
- [ ] Switch language to Arabic → confirm row flips RTL automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)