### PR TITLE
fix: keep image/icon choice card height stable across rows

### DIFF
--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -1,6 +1,6 @@
 import styles from "./IconChoiceItemDesign.module.css";
 import btnStyles from "~/components/Questions/shared/choiceItemButtons.module.css";
-import { alpha, Box, Grid, IconButton, TextField } from "@mui/material";
+import { alpha, Box, IconButton, TextField } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
@@ -204,38 +204,30 @@ function IconChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid item xs={12 / columnNumber} height="100%" key="add">
-      <Box
-        className={styles.addAnswerButton}
-        style={{
-          minHeight: "100px",
-          borderRadius: "4px",
-          backgroundColor: theme.palette.background.default,
-          height: "100%",
-          width: "100%",
-        }}
-      >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
-          }}
-        >
-          <AddIcon />
-        </IconButton>
-      </Box>
-    </Grid>
+    <Box
+      className={styles.addAnswerButton}
+      onClick={() => addAnswer()}
+      style={{
+        minHeight: "100px",
+        borderRadius: "4px",
+        backgroundColor: theme.palette.background.default,
+        height: "100%",
+        width: "100%",
+        cursor: "pointer",
+      }}
+    >
+      <IconButton className={styles.addAnswerIcon}>
+        <AddIcon />
+      </IconButton>
+    </Box>
   ) : (
     <>
-      <Grid
+      <Box
         style={{
           opacity: isDragging ? "0.2" : "1",
         }}
-        item
         data-code={code}
-        position="relative"
-        xs={12 / columnNumber}
-        key={qualifiedCode}
+        sx={{ position: "relative", height: "100%", width: "100%" }}
       >
         {isInSetup && (
           <div
@@ -298,7 +290,9 @@ function IconChoiceItemDesign({
           <div
             style={{
               width: "100%",
+              flex: 1,
               display: "flex",
+              alignItems: "center",
               justifyContent: "center",
             }}
           >
@@ -329,7 +323,7 @@ function IconChoiceItemDesign({
             />
           )}
         </div>
-      </Grid>
+      </Box>
       {iconSelectoOpen && (
         <IconSelector
           currentIcon=""

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -27,6 +27,8 @@ import { setupOptions } from "~/constants/design";
 import { Build } from "@mui/icons-material";
 import ContentEditor from "~/components/design/ContentEditor";
 import InlineCodeEditor from "~/components/design/InlineCodeEditor";
+import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 
 function IconChoiceItemDesign({
   parentCode,
@@ -47,7 +49,7 @@ function IconChoiceItemDesign({
   const ref = useRef(null);
   const theme = useTheme();
   const [iconSelectoOpen, setIconSelectorOpen] = useState(false);
-
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const answer = useSelector((state) => {
     return type == "add" ? undefined : state.designState[qualifiedCode];
@@ -67,9 +69,12 @@ function IconChoiceItemDesign({
     type == "add" ? undefined : answer.content?.[langInfo.mainLang]?.["label"];
 
   const onDelete = () => {
-    if (window.confirm(t("are_you_sure"))) {
-      dispatch(removeAnswer(qualifiedCode));
-    }
+    setConfirmDeleteOpen(true);
+  };
+
+  const onConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    dispatch(removeAnswer(qualifiedCode));
   };
 
   const isInSetup = useSelector((state) => {
@@ -335,6 +340,18 @@ function IconChoiceItemDesign({
             setIconSelectorOpen(false);
           }}
         />
+      )}
+      {confirmDeleteOpen && (
+        <AppThemeProvider>
+          <ConfirmActionModal
+            open
+            onClose={() => setConfirmDeleteOpen(false)}
+            onConfirm={onConfirmDelete}
+            title={t("are_you_sure")}
+            cancelLabel={t("cancel")}
+            confirmLabel={t("delete")}
+          />
+        </AppThemeProvider>
       )}
     </>
   );

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
@@ -2,6 +2,13 @@
   scale: 2;
 }
 
+.imageContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
 .overlay {
   z-index: 1;
   position: absolute;

--- a/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./ImageChoiceDesign.module.css";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Box, Grid } from "@mui/material";
+import { Box } from "@mui/material";
 import ImageChoiceItemDesign from "./ImageChoiceItemDesign";
 import IconChoiceItemDesign from "../Iconchoice/IconChoiceItemDesign";
 import { inDesign } from "~/routes";
@@ -31,73 +31,56 @@ function ImageChoiceQuestion(props) {
   const spacing = state.spacing || 8;
   const imageHeight = state.iconSize ? +state.iconSize : 64;
 
-  const itemWidth = `calc(${100 / columnNumber}% - ${spacing}px)`;
-
   return (
     <div className={styles.questionItem}>
       {imageHeight && (
         <Box
           id={"items-" + props.code}
           sx={{
-            display: "flex",
-            flexWrap: "wrap",
+            display: "grid",
+            gridTemplateColumns: `repeat(${columnNumber}, minmax(0, 1fr))`,
+            gridAutoRows: "1fr",
             gap: `${spacing}px`,
           }}
         >
           {childrenWithAdd.map((item, index) =>
             props.icon ? (
-              <Box
+              <IconChoiceItemDesign
                 key={item.code}
-                sx={{
-                  flex: `0 1 ${itemWidth}`,
-                  maxWidth: itemWidth,
-                }}
-              >
-                <IconChoiceItemDesign
-                  key={item.code}
-                  code={item.code}
-                  langInfo={props.langInfo}
-                  parentCode={props.code}
-                  index={index}
-                  columnNumber={columnNumber}
-                  designMode={props.designMode}
-                  hideText={hideText}
-                  imageHeight={imageHeight}
-                  t={props.t}
-                  addAnswer={() =>
-                    dispatch(addNewAnswer({ questionCode: props.code }))
-                  }
-                  type={item.type}
-                  qualifiedCode={item.qualifiedCode}
-                />
-              </Box>
+                code={item.code}
+                langInfo={props.langInfo}
+                parentCode={props.code}
+                index={index}
+                columnNumber={columnNumber}
+                designMode={props.designMode}
+                hideText={hideText}
+                imageHeight={imageHeight}
+                t={props.t}
+                addAnswer={() =>
+                  dispatch(addNewAnswer({ questionCode: props.code }))
+                }
+                type={item.type}
+                qualifiedCode={item.qualifiedCode}
+              />
             ) : (
-              <Box
+              <ImageChoiceItemDesign
                 key={item.code}
-                sx={{
-                  flex: `0 1 ${itemWidth}`,
-                  maxWidth: itemWidth,
-                }}
-              >
-                <ImageChoiceItemDesign
-                  key={item.code}
-                  code={item.code}
-                  langInfo={props.langInfo}
-                  parentCode={props.code}
-                  index={index}
-                  imageAspectRatio={imageAspectRatio}
-                  columnNumber={columnNumber}
-                  hideText={hideText}
-                  designMode={props.designMode}
-                  imageHeight={imageHeight}
-                  t={props.t}
-                  addAnswer={() =>
-                    dispatch(addNewAnswer({ questionCode: props.code }))
-                  }
-                  type={item.type}
-                  qualifiedCode={item.qualifiedCode}
-                />
-              </Box>
+                code={item.code}
+                langInfo={props.langInfo}
+                parentCode={props.code}
+                index={index}
+                imageAspectRatio={imageAspectRatio}
+                columnNumber={columnNumber}
+                hideText={hideText}
+                designMode={props.designMode}
+                imageHeight={imageHeight}
+                t={props.t}
+                addAnswer={() =>
+                  dispatch(addNewAnswer({ questionCode: props.code }))
+                }
+                type={item.type}
+                qualifiedCode={item.qualifiedCode}
+              />
             )
           )}
         </Box>

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -1,6 +1,6 @@
 import styles from "./ImageChoiceItemDesign.module.css";
 import btnStyles from "~/components/Questions/shared/choiceItemButtons.module.css";
-import { alpha, Box, css, Grid, IconButton, TextField } from "@mui/material";
+import { alpha, Box, css, IconButton, TextField } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
@@ -210,139 +210,130 @@ function ImageChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid height="100%" item xs={12 / columnNumber} key="add">
-      <Box
-        className={styles.addAnswerButton}
-        style={{
-          minHeight: "100px",
-          height: "100%",
-          width: "100%",
-          backgroundColor: theme.palette.background.default,
-          borderRadius: "4px",
-        }}
-      >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
-          }}
-        >
-          <AddIcon />
-        </IconButton>
-      </Box>
-    </Grid>
+    <Box
+      className={styles.addAnswerButton}
+      onClick={() => addAnswer()}
+      style={{
+        minHeight: "100px",
+        width: "100%",
+        aspectRatio: imageAspectRatio,
+        alignSelf: "start",
+        backgroundColor: theme.palette.background.default,
+        borderRadius: "4px",
+        cursor: "pointer",
+      }}
+    >
+      <IconButton className={styles.addAnswerIcon}>
+        <AddIcon />
+      </IconButton>
+    </Box>
   ) : (
-    <>
-      <Grid
-        style={{
-          opacity: isDragging ? "0.2" : "1",
-        }}
-        item
-        data-code={code}
-        position="relative"
-        xs={12 / columnNumber}
-        key={qualifiedCode}
-      >
-        {isInSetup && (
-          <div
-            className={styles.overlay}
-            style={{ backgroundColor: contrastColor }}
-          />
-        )}
+    <Box
+      style={{
+        opacity: isDragging ? "0.2" : "1",
+      }}
+      data-code={code}
+      sx={{ position: "relative", height: "100%", width: "100%" }}
+    >
+      {isInSetup && (
         <div
-          className={styles.imageContainer}
-          style={{
-            paddingTop: 100 / imageAspectRatio + "%",
-            backgroundImage: backgroundImage,
-          }}
-          ref={ref}
-          data-handler-id={handlerId}
-        >
-          {inDesign(designMode) && (
-            <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
-              <div className={btnStyles.leftZone}>
-                <IconButton ref={drag} className={btnStyles.iconButton}>
-                  <DragIndicatorIcon color="action" />
-                </IconButton>
-                <div className={btnStyles.codeWrapper}>
-                  <InlineCodeEditor
-                    qualifiedCode={qualifiedCode}
-                    designMode={designMode}
-                    compact
-                  />
-                </div>
-              </div>
-              <div className={btnStyles.rightZone}>
-                <IconButton
-                  className={btnStyles.iconButton}
-                  onClick={() => {
-                    onDelete();
-                  }}
-                >
-                  <DeleteOutlineIcon />
-                </IconButton>
-                <IconButton
-                  className={btnStyles.iconButton}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    dispatch(
-                      setup({
-                        code: qualifiedCode,
-                        rules: setupOptions("options"),
-                      })
-                    );
-                  }}
-                >
-                  <Build />
-                </IconButton>
-                <IconButton
-                  component="label"
-                  className={btnStyles.iconButton}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  <PhotoCamera />
-                  <input
-                    hidden
-                    id={`file-input-${qualifiedCode}`}
-                    accept="image/*"
-                    type="file"
-                    onChange={handleImageChange}
-                  />
-                </IconButton>
+          className={styles.overlay}
+          style={{ backgroundColor: contrastColor }}
+        />
+      )}
+      <div
+        className={styles.imageContainer}
+        style={{
+          paddingTop: 100 / imageAspectRatio + "%",
+          backgroundImage: backgroundImage,
+        }}
+        ref={ref}
+        data-handler-id={handlerId}
+      >
+        {inDesign(designMode) && (
+          <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
+            <div className={btnStyles.leftZone}>
+              <IconButton ref={drag} className={btnStyles.iconButton}>
+                <DragIndicatorIcon color="action" />
+              </IconButton>
+              <div className={btnStyles.codeWrapper}>
+                <InlineCodeEditor
+                  qualifiedCode={qualifiedCode}
+                  designMode={designMode}
+                  compact
+                />
               </div>
             </div>
-          )}
-
-          {isUploading && (
-            <div className={styles.loadingContainer}>
-              <LoadingDots />
+            <div className={btnStyles.rightZone}>
+              <IconButton
+                className={btnStyles.iconButton}
+                onClick={() => {
+                  onDelete();
+                }}
+              >
+                <DeleteOutlineIcon />
+              </IconButton>
+              <IconButton
+                className={btnStyles.iconButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dispatch(
+                    setup({
+                      code: qualifiedCode,
+                      rules: setupOptions("options"),
+                    })
+                  );
+                }}
+              >
+                <Build />
+              </IconButton>
+              <IconButton
+                component="label"
+                className={btnStyles.iconButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <PhotoCamera />
+                <input
+                  hidden
+                  id={`file-input-${qualifiedCode}`}
+                  accept="image/*"
+                  type="file"
+                  onChange={handleImageChange}
+                />
+              </IconButton>
             </div>
-          )}
-        </div>
-        {!hideText && (
-          <ContentEditor
-            code={qualifiedCode}
-            showToolbar={false}
-            editable={contentEditable(designMode)}
-            extended={false}
-            centerText
-            placeholder={
-              onMainLang
-                ? t("content_editor_placeholder_option", {
-                    lng: langInfo.mainLang,
-                  })
-                : mainContent ||
-                  t("content_editor_placeholder_option", {
-                    lng: langInfo.mainLang,
-                  })
-            }
-            contentKey="label"
-          />
+          </div>
         )}
-      </Grid>
-    </>
+
+        {isUploading && (
+          <div className={styles.loadingContainer}>
+            <LoadingDots />
+          </div>
+        )}
+      </div>
+      {!hideText && (
+        <ContentEditor
+          code={qualifiedCode}
+          showToolbar={false}
+          editable={contentEditable(designMode)}
+          extended={false}
+          centerText
+          placeholder={
+            onMainLang
+              ? t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+              : mainContent ||
+                t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+          }
+          contentKey="label"
+        />
+      )}
+    </Box>
   );
 }
 

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -26,6 +26,8 @@ import { Build } from "@mui/icons-material";
 import { setupOptions } from "~/constants/design";
 import ContentEditor from "~/components/design/ContentEditor";
 import InlineCodeEditor from "~/components/design/InlineCodeEditor";
+import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 
 function ImageChoiceItemDesign({
   parentCode,
@@ -46,6 +48,7 @@ function ImageChoiceItemDesign({
   const theme = useTheme();
   const ref = useRef();
   const [isUploading, setUploading] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const answer = useSelector((state) => {
     return type == "add" ? undefined : state.designState[qualifiedCode];
@@ -69,9 +72,12 @@ function ImageChoiceItemDesign({
   });
 
   const onDelete = () => {
-    if (window.confirm(t("are_you_sure"))) {
-      dispatch(removeAnswer(qualifiedCode));
-    }
+    setConfirmDeleteOpen(true);
+  };
+
+  const onConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    dispatch(removeAnswer(qualifiedCode));
   };
 
   const isInSetup = useSelector((state) => {
@@ -332,6 +338,18 @@ function ImageChoiceItemDesign({
           }
           contentKey="label"
         />
+      )}
+      {confirmDeleteOpen && (
+        <AppThemeProvider>
+          <ConfirmActionModal
+            open
+            onClose={() => setConfirmDeleteOpen(false)}
+            onConfirm={onConfirmDelete}
+            title={t("are_you_sure")}
+            cancelLabel={t("cancel")}
+            confirmLabel={t("delete")}
+          />
+        </AppThemeProvider>
       )}
     </Box>
   );

--- a/src/components/design/ActionToolbar/index.jsx
+++ b/src/components/design/ActionToolbar/index.jsx
@@ -13,6 +13,7 @@ import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { RuleOutlined, VisibilityOff } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 import SurveyIcon from "~/components/common/SurveyIcons/SurveyIcon";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
 
@@ -229,18 +230,22 @@ function ActionToolbar({ code, isGroup, parentCode, showActions }) {
               <SurveyIcon name="delete" size="1em" color="currentColor" />
             </IconButton>
           </CustomTooltip>
-          <ConfirmActionModal
-            open={deleteModalOpen}
-            title={t("delete")}
-            description={t(isGroup ? "delete_page" : "delete_question")}
-            cancelLabel={t("cancel")}
-            confirmLabel={t("delete")}
-            onClose={() => setDeleteModalOpen(false)}
-            onConfirm={() => {
-              setDeleteModalOpen(false);
-              onDelete();
-            }}
-          />
+          {deleteModalOpen && (
+            <AppThemeProvider>
+              <ConfirmActionModal
+                open
+                title={t("delete")}
+                description={t(isGroup ? "delete_page" : "delete_question")}
+                cancelLabel={t("cancel")}
+                confirmLabel={t("delete")}
+                onClose={() => setDeleteModalOpen(false)}
+                onConfirm={() => {
+                  setDeleteModalOpen(false);
+                  onDelete();
+                }}
+              />
+            </AppThemeProvider>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes for the image/icon **choice question** designer, plus a theming fix for the delete-confirmation modals.

## 1. Choice card height stable across rows

In the survey design editor, the **"Add answer"** card in image-choice and icon-choice grids rendered at a **different height depending on its row** — it matched its neighbours when sharing a row with options, but shrank when it sat alone in the last row.

The option grid used `display:flex; flex-wrap:wrap`; default `align-items:stretch` only stretches cards within their own flex line, so the Add card's `height:100%` resolved against a stretched wrapper in a shared row but collapsed to `minHeight` when alone — same card, two heights.

**Changes**
- **ImageChoiceDesign** — option grid switched from flex-wrap to CSS Grid with `grid-auto-rows: 1fr`, so every row is a uniform height and grid cells have a definite height.
- **ImageChoiceItemDesign / IconChoiceItemDesign** — replaced the misused `<Grid item>` roots (rendered outside any `<Grid container>`) with `<Box>`; removed the now-unused `Grid` imports.
- Add card sized to the image aspect ratio (aligned with the option image boxes) and made **fully clickable** — the whole card responds, not just the `+` icon.
- **IconChoiceItemDesign.module.css** — added the missing `.imageContainer` class.

_Trade-off:_ with `grid-auto-rows: 1fr`, a long wrapping label on any option grows every card in the grid to match.

## 2. Delete confirmation modal

- Replaced the native `window.confirm` used when deleting an image/icon choice **option** with the shared `ConfirmActionModal`.
- Delete-confirmation modals triggered from inside the survey-design canvas — the choice-option delete and the **question/page delete** in `ActionToolbar` — inherited the **survey's theme**, which made the Cancel button's text invisible against the modal's white background. They are now wrapped in the app `ThemeProvider` so they render with the admin theme (Cancel readable, correct palette). The wrapper is mounted only while the modal is open.

## Test plan

- **Card height** — image-choice question, `columns = 2`: with 2 options the Add card lands alone in the last row; with 3 it shares a row — confirm the Add card is identical height in both and matches the image boxes. Repeat for icon-choice; vary icon size.
- **Drag-reorder** options in both grids.
- **Option delete** — delete an image/icon choice option: the `ConfirmActionModal` appears with both **Cancel** and **Delete** visible; Cancel dismisses, Delete removes the option.
- **Question/page delete** — delete a question and a group/page from the toolbar: confirm both **Cancel** and **Delete** are visible and behave correctly.
- No console warning about `<Grid>` used outside a `<Grid container>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)