### PR TITLE
fix: keep image/icon choice card height stable across rows

### DIFF
--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -1,6 +1,6 @@
 import styles from "./IconChoiceItemDesign.module.css";
 import btnStyles from "~/components/Questions/shared/choiceItemButtons.module.css";
-import { alpha, Box, Grid, IconButton, TextField } from "@mui/material";
+import { alpha, Box, IconButton, TextField } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
@@ -204,38 +204,30 @@ function IconChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid item xs={12 / columnNumber} height="100%" key="add">
-      <Box
-        className={styles.addAnswerButton}
-        style={{
-          minHeight: "100px",
-          borderRadius: "4px",
-          backgroundColor: theme.palette.background.default,
-          height: "100%",
-          width: "100%",
-        }}
-      >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
-          }}
-        >
-          <AddIcon />
-        </IconButton>
-      </Box>
-    </Grid>
+    <Box
+      className={styles.addAnswerButton}
+      onClick={() => addAnswer()}
+      style={{
+        minHeight: "100px",
+        borderRadius: "4px",
+        backgroundColor: theme.palette.background.default,
+        height: "100%",
+        width: "100%",
+        cursor: "pointer",
+      }}
+    >
+      <IconButton className={styles.addAnswerIcon}>
+        <AddIcon />
+      </IconButton>
+    </Box>
   ) : (
     <>
-      <Grid
+      <Box
         style={{
           opacity: isDragging ? "0.2" : "1",
         }}
-        item
         data-code={code}
-        position="relative"
-        xs={12 / columnNumber}
-        key={qualifiedCode}
+        sx={{ position: "relative", height: "100%", width: "100%" }}
       >
         {isInSetup && (
           <div
@@ -298,7 +290,9 @@ function IconChoiceItemDesign({
           <div
             style={{
               width: "100%",
+              flex: 1,
               display: "flex",
+              alignItems: "center",
               justifyContent: "center",
             }}
           >
@@ -329,7 +323,7 @@ function IconChoiceItemDesign({
             />
           )}
         </div>
-      </Grid>
+      </Box>
       {iconSelectoOpen && (
         <IconSelector
           currentIcon=""

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
@@ -2,6 +2,13 @@
   scale: 2;
 }
 
+.imageContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
 .overlay {
   z-index: 1;
   position: absolute;

--- a/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./ImageChoiceDesign.module.css";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Box, Grid } from "@mui/material";
+import { Box } from "@mui/material";
 import ImageChoiceItemDesign from "./ImageChoiceItemDesign";
 import IconChoiceItemDesign from "../Iconchoice/IconChoiceItemDesign";
 import { inDesign } from "~/routes";
@@ -31,73 +31,56 @@ function ImageChoiceQuestion(props) {
   const spacing = state.spacing || 8;
   const imageHeight = state.iconSize ? +state.iconSize : 64;
 
-  const itemWidth = `calc(${100 / columnNumber}% - ${spacing}px)`;
-
   return (
     <div className={styles.questionItem}>
       {imageHeight && (
         <Box
           id={"items-" + props.code}
           sx={{
-            display: "flex",
-            flexWrap: "wrap",
+            display: "grid",
+            gridTemplateColumns: `repeat(${columnNumber}, minmax(0, 1fr))`,
+            gridAutoRows: "1fr",
             gap: `${spacing}px`,
           }}
         >
           {childrenWithAdd.map((item, index) =>
             props.icon ? (
-              <Box
+              <IconChoiceItemDesign
                 key={item.code}
-                sx={{
-                  flex: `0 1 ${itemWidth}`,
-                  maxWidth: itemWidth,
-                }}
-              >
-                <IconChoiceItemDesign
-                  key={item.code}
-                  code={item.code}
-                  langInfo={props.langInfo}
-                  parentCode={props.code}
-                  index={index}
-                  columnNumber={columnNumber}
-                  designMode={props.designMode}
-                  hideText={hideText}
-                  imageHeight={imageHeight}
-                  t={props.t}
-                  addAnswer={() =>
-                    dispatch(addNewAnswer({ questionCode: props.code }))
-                  }
-                  type={item.type}
-                  qualifiedCode={item.qualifiedCode}
-                />
-              </Box>
+                code={item.code}
+                langInfo={props.langInfo}
+                parentCode={props.code}
+                index={index}
+                columnNumber={columnNumber}
+                designMode={props.designMode}
+                hideText={hideText}
+                imageHeight={imageHeight}
+                t={props.t}
+                addAnswer={() =>
+                  dispatch(addNewAnswer({ questionCode: props.code }))
+                }
+                type={item.type}
+                qualifiedCode={item.qualifiedCode}
+              />
             ) : (
-              <Box
+              <ImageChoiceItemDesign
                 key={item.code}
-                sx={{
-                  flex: `0 1 ${itemWidth}`,
-                  maxWidth: itemWidth,
-                }}
-              >
-                <ImageChoiceItemDesign
-                  key={item.code}
-                  code={item.code}
-                  langInfo={props.langInfo}
-                  parentCode={props.code}
-                  index={index}
-                  imageAspectRatio={imageAspectRatio}
-                  columnNumber={columnNumber}
-                  hideText={hideText}
-                  designMode={props.designMode}
-                  imageHeight={imageHeight}
-                  t={props.t}
-                  addAnswer={() =>
-                    dispatch(addNewAnswer({ questionCode: props.code }))
-                  }
-                  type={item.type}
-                  qualifiedCode={item.qualifiedCode}
-                />
-              </Box>
+                code={item.code}
+                langInfo={props.langInfo}
+                parentCode={props.code}
+                index={index}
+                imageAspectRatio={imageAspectRatio}
+                columnNumber={columnNumber}
+                hideText={hideText}
+                designMode={props.designMode}
+                imageHeight={imageHeight}
+                t={props.t}
+                addAnswer={() =>
+                  dispatch(addNewAnswer({ questionCode: props.code }))
+                }
+                type={item.type}
+                qualifiedCode={item.qualifiedCode}
+              />
             )
           )}
         </Box>

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -1,6 +1,6 @@
 import styles from "./ImageChoiceItemDesign.module.css";
 import btnStyles from "~/components/Questions/shared/choiceItemButtons.module.css";
-import { alpha, Box, css, Grid, IconButton, TextField } from "@mui/material";
+import { alpha, Box, css, IconButton, TextField } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
@@ -210,139 +210,130 @@ function ImageChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid height="100%" item xs={12 / columnNumber} key="add">
-      <Box
-        className={styles.addAnswerButton}
-        style={{
-          minHeight: "100px",
-          height: "100%",
-          width: "100%",
-          backgroundColor: theme.palette.background.default,
-          borderRadius: "4px",
-        }}
-      >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
-          }}
-        >
-          <AddIcon />
-        </IconButton>
-      </Box>
-    </Grid>
+    <Box
+      className={styles.addAnswerButton}
+      onClick={() => addAnswer()}
+      style={{
+        minHeight: "100px",
+        width: "100%",
+        aspectRatio: imageAspectRatio,
+        alignSelf: "start",
+        backgroundColor: theme.palette.background.default,
+        borderRadius: "4px",
+        cursor: "pointer",
+      }}
+    >
+      <IconButton className={styles.addAnswerIcon}>
+        <AddIcon />
+      </IconButton>
+    </Box>
   ) : (
-    <>
-      <Grid
-        style={{
-          opacity: isDragging ? "0.2" : "1",
-        }}
-        item
-        data-code={code}
-        position="relative"
-        xs={12 / columnNumber}
-        key={qualifiedCode}
-      >
-        {isInSetup && (
-          <div
-            className={styles.overlay}
-            style={{ backgroundColor: contrastColor }}
-          />
-        )}
+    <Box
+      style={{
+        opacity: isDragging ? "0.2" : "1",
+      }}
+      data-code={code}
+      sx={{ position: "relative", height: "100%", width: "100%" }}
+    >
+      {isInSetup && (
         <div
-          className={styles.imageContainer}
-          style={{
-            paddingTop: 100 / imageAspectRatio + "%",
-            backgroundImage: backgroundImage,
-          }}
-          ref={ref}
-          data-handler-id={handlerId}
-        >
-          {inDesign(designMode) && (
-            <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
-              <div className={btnStyles.leftZone}>
-                <IconButton ref={drag} className={btnStyles.iconButton}>
-                  <DragIndicatorIcon color="action" />
-                </IconButton>
-                <div className={btnStyles.codeWrapper}>
-                  <InlineCodeEditor
-                    qualifiedCode={qualifiedCode}
-                    designMode={designMode}
-                    compact
-                  />
-                </div>
-              </div>
-              <div className={btnStyles.rightZone}>
-                <IconButton
-                  className={btnStyles.iconButton}
-                  onClick={() => {
-                    onDelete();
-                  }}
-                >
-                  <DeleteOutlineIcon />
-                </IconButton>
-                <IconButton
-                  className={btnStyles.iconButton}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    dispatch(
-                      setup({
-                        code: qualifiedCode,
-                        rules: setupOptions("options"),
-                      })
-                    );
-                  }}
-                >
-                  <Build />
-                </IconButton>
-                <IconButton
-                  component="label"
-                  className={btnStyles.iconButton}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  <PhotoCamera />
-                  <input
-                    hidden
-                    id={`file-input-${qualifiedCode}`}
-                    accept="image/*"
-                    type="file"
-                    onChange={handleImageChange}
-                  />
-                </IconButton>
+          className={styles.overlay}
+          style={{ backgroundColor: contrastColor }}
+        />
+      )}
+      <div
+        className={styles.imageContainer}
+        style={{
+          paddingTop: 100 / imageAspectRatio + "%",
+          backgroundImage: backgroundImage,
+        }}
+        ref={ref}
+        data-handler-id={handlerId}
+      >
+        {inDesign(designMode) && (
+          <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
+            <div className={btnStyles.leftZone}>
+              <IconButton ref={drag} className={btnStyles.iconButton}>
+                <DragIndicatorIcon color="action" />
+              </IconButton>
+              <div className={btnStyles.codeWrapper}>
+                <InlineCodeEditor
+                  qualifiedCode={qualifiedCode}
+                  designMode={designMode}
+                  compact
+                />
               </div>
             </div>
-          )}
-
-          {isUploading && (
-            <div className={styles.loadingContainer}>
-              <LoadingDots />
+            <div className={btnStyles.rightZone}>
+              <IconButton
+                className={btnStyles.iconButton}
+                onClick={() => {
+                  onDelete();
+                }}
+              >
+                <DeleteOutlineIcon />
+              </IconButton>
+              <IconButton
+                className={btnStyles.iconButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dispatch(
+                    setup({
+                      code: qualifiedCode,
+                      rules: setupOptions("options"),
+                    })
+                  );
+                }}
+              >
+                <Build />
+              </IconButton>
+              <IconButton
+                component="label"
+                className={btnStyles.iconButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <PhotoCamera />
+                <input
+                  hidden
+                  id={`file-input-${qualifiedCode}`}
+                  accept="image/*"
+                  type="file"
+                  onChange={handleImageChange}
+                />
+              </IconButton>
             </div>
-          )}
-        </div>
-        {!hideText && (
-          <ContentEditor
-            code={qualifiedCode}
-            showToolbar={false}
-            editable={contentEditable(designMode)}
-            extended={false}
-            centerText
-            placeholder={
-              onMainLang
-                ? t("content_editor_placeholder_option", {
-                    lng: langInfo.mainLang,
-                  })
-                : mainContent ||
-                  t("content_editor_placeholder_option", {
-                    lng: langInfo.mainLang,
-                  })
-            }
-            contentKey="label"
-          />
+          </div>
         )}
-      </Grid>
-    </>
+
+        {isUploading && (
+          <div className={styles.loadingContainer}>
+            <LoadingDots />
+          </div>
+        )}
+      </div>
+      {!hideText && (
+        <ContentEditor
+          code={qualifiedCode}
+          showToolbar={false}
+          editable={contentEditable(designMode)}
+          extended={false}
+          centerText
+          placeholder={
+            onMainLang
+              ? t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+              : mainContent ||
+                t("content_editor_placeholder_option", {
+                  lng: langInfo.mainLang,
+                })
+          }
+          contentKey="label"
+        />
+      )}
+    </Box>
   );
 }
 


### PR DESCRIPTION
## Summary
The "Add answer" card changed height depending on whether it shared a row with options or sat alone in the last row: the flex-wrap layout only stretched cards within their own flex line.

- ImageChoiceDesign: lay options out with CSS Grid + grid-auto-rows:1fr so every row is a uniform height
- ImageChoiceItemDesign / IconChoiceItemDesign: replace the misused `<Grid item>` roots (rendered outside any `<Grid container>`) with `<Box>`
- size the Add card to the image aspect ratio and make the whole card clickable
- IconChoiceItemDesign.module.css: add the missing .imageContainer class

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Create an image-choice question with options of varying label lengths; confirm cards in the same row are equal height
- [ ] Confirm the Add card stays the same height as siblings in the last row

🤖 Generated with [Claude Code](https://claude.com/claude-code)