### PR TITLE
fix: render delete confirm modal with the app theme

### DIFF
--- a/src/components/design/ActionToolbar/index.jsx
+++ b/src/components/design/ActionToolbar/index.jsx
@@ -13,6 +13,7 @@ import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { RuleOutlined, VisibilityOff } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 import SurveyIcon from "~/components/common/SurveyIcons/SurveyIcon";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
 
@@ -229,18 +230,22 @@ function ActionToolbar({ code, isGroup, parentCode, showActions }) {
               <SurveyIcon name="delete" size="1em" color="currentColor" />
             </IconButton>
           </CustomTooltip>
-          <ConfirmActionModal
-            open={deleteModalOpen}
-            title={t("delete")}
-            description={t(isGroup ? "delete_page" : "delete_question")}
-            cancelLabel={t("cancel")}
-            confirmLabel={t("delete")}
-            onClose={() => setDeleteModalOpen(false)}
-            onConfirm={() => {
-              setDeleteModalOpen(false);
-              onDelete();
-            }}
-          />
+          {deleteModalOpen && (
+            <AppThemeProvider>
+              <ConfirmActionModal
+                open
+                title={t("delete")}
+                description={t(isGroup ? "delete_page" : "delete_question")}
+                cancelLabel={t("cancel")}
+                confirmLabel={t("delete")}
+                onClose={() => setDeleteModalOpen(false)}
+                onConfirm={() => {
+                  setDeleteModalOpen(false);
+                  onDelete();
+                }}
+              />
+            </AppThemeProvider>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
ActionToolbar's delete ConfirmActionModal inherited the survey theme, making the Cancel button's text invisible on the modal's white background. Wrap it in the app ThemeProvider, same as the choice-item delete modals.

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Delete a question / page; confirm the modal matches the app theme on both light and dark survey themes
- [ ] Confirm Cancel button text is visible against the white modal background

🤖 Generated with [Claude Code](https://claude.com/claude-code)