### PR TITLE
fix: adjust loadingContainer styles for proper centering

### DIFF
--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
@@ -24,9 +24,10 @@
 }
 
 .loadingContainer {
+  position: absolute;
   top: 50%;
   left: 50%;
-  position: absolute;
+  transform: translate(-50%, -50%);
 }
 
 .addAnswerButton {


### PR DESCRIPTION
## Summary
Three-line fix: add `transform: translate(-50%, -50%)` so the loading spinner in image-choice option cards centers on the tile instead of anchoring to its top-left corner.

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Upload an image to an image-choice option; confirm the loading spinner is visually centered on the tile while uploading

🤖 Generated with [Claude Code](https://claude.com/claude-code)