### PR TITLE
fix: guard choice-question answers against missing field

### DIFF
--- a/src/components/Questions/IconMcq/IconMcq.jsx
+++ b/src/components/Questions/IconMcq/IconMcq.jsx
@@ -26,7 +26,7 @@ function IconMcq(props) {
       }}
       className={styles.iconFlexContainer}
     >
-      {props.component.answers.map((option) => {
+      {(props.component.answers || []).map((option) => {
         const relevance = runValues[option.qualifiedCode]?.relevance ?? true;
         if (!relevance) return null;
 

--- a/src/components/Questions/IconScq/IconScq.jsx
+++ b/src/components/Questions/IconScq/IconScq.jsx
@@ -37,7 +37,7 @@ function IconScq(props) {
       }}
       className={styles.iconFlexContainer}
     >
-      {props.component.answers.map((option) => {
+      {(props.component.answers || []).map((option) => {
         const isSelected = state.value == option.code;
         const relevance = runValues[option.qualifiedCode]?.relevance ?? true;
         if (!relevance) return null;

--- a/src/components/Questions/ImageMcq/ImageMcq.jsx
+++ b/src/components/Questions/ImageMcq/ImageMcq.jsx
@@ -29,7 +29,7 @@ function ImageMcq(props) {
       }}
       className={styles.imageFlexContainer}
     >
-      {props.component.answers.map((option) => {
+      {(props.component.answers || []).map((option) => {
         const relevance = runValues[option.qualifiedCode]?.relevance ?? true;
         if (!relevance) return null;
 

--- a/src/components/Questions/ImageRanking/ImageRanking.jsx
+++ b/src/components/Questions/ImageRanking/ImageRanking.jsx
@@ -11,9 +11,10 @@ import { rtlLanguage } from "~/utils/common";
 import Content from '~/components/run/Content';
 
 function ImageRanking(props) {
+  const answers = props.component.answers || [];
   const values = useSelector((state) => {
     let valuesMap = {};
-    props.component.answers.forEach((element) => {
+    answers.forEach((element) => {
       valuesMap[element.qualifiedCode] =
         state.runState.values[element.qualifiedCode].value;
     });
@@ -76,7 +77,7 @@ function ImageRanking(props) {
       }}
       className={styles.imageFlexContainer}
     >
-      {props.component.answers.map((option) => {
+      {answers.map((option) => {
         return (
           <ImageRankingItem
             option={option}

--- a/src/components/Questions/ImageScq/ImageScq.jsx
+++ b/src/components/Questions/ImageScq/ImageScq.jsx
@@ -41,7 +41,7 @@ function ImageScq(props) {
       }}
       className={styles.imageFlexContainer}
     >
-      {props.component.answers.map((option) => {
+      {(props.component.answers || []).map((option) => {
         const backgroundImage = option.resources?.image
           ? `url('${buildResourceUrl(option.resources?.image)}')`
           : `url('/placeholder-image.jpg')`;

--- a/src/components/Questions/Mcq/Mcq.jsx
+++ b/src/components/Questions/Mcq/Mcq.jsx
@@ -14,11 +14,12 @@ import { setDirty } from "~/state/templateState";
 import MCQAnswer from "./MCQAnswer";
 
 function MCQ(props) {
+  const answers = props.component.answers || [];
   const parentValue = useSelector((state) => {
     return state.runState.values[props.component.qualifiedCode].value || [];
   }, shallowEqual);
-  const hasAll = props.component.answers.some((answer) => answer.type == "all");
-  const allCodes = props.component.answers
+  const hasAll = answers.some((answer) => answer.type == "all");
+  const allCodes = answers
     .filter(
       (answer) =>
         answer.type !== "all" &&
@@ -33,7 +34,7 @@ function MCQ(props) {
   return (
     <FormControl component="fieldset">
       <FormGroup>
-        {props.component.answers.map((option) => {
+        {answers.map((option) => {
           if (option.type === "other") {
             return (
               <McqAnswerOther

--- a/src/components/Questions/MultipleText/MultipleText.jsx
+++ b/src/components/Questions/MultipleText/MultipleText.jsx
@@ -16,7 +16,7 @@ function MultipleText(props) {
         flexDirection: "column",
       }}
     >
-      {props.component.answers.map((option) => {
+      {(props.component.answers || []).map((option) => {
         return <MultipleTextItem key={option.qualifiedCode} item={option} />;
       })}
     </Box>

--- a/src/components/Questions/Ranking/Ranking.jsx
+++ b/src/components/Questions/Ranking/Ranking.jsx
@@ -18,7 +18,7 @@ function Ranking(props) {
 
   const visibleAnswers = useSelector(
     (state) =>
-      props.component.answers.filter((ans) => {
+      (props.component.answers || []).filter((ans) => {
         return state.runState.values[ans.qualifiedCode]?.relevance ?? true;
       }),
     shallowEqual

--- a/src/components/Questions/SCQArray/Array.jsx
+++ b/src/components/Questions/SCQArray/Array.jsx
@@ -16,10 +16,9 @@ import Content from "~/components/run/Content";
 
 function Array(props) {
   const theme = useTheme();
-  let columns = props.component.answers.filter(
-    (answer) => answer.type == "column"
-  );
-  let rows = props.component.answers.filter((answer) => answer.type == "row");
+  const answers = props.component.answers || [];
+  let columns = answers.filter((answer) => answer.type == "column");
+  let rows = answers.filter((answer) => answer.type == "row");
   const { header, rowLabel } = useColumnMinWidth(null, props.component);
 
   return (

--- a/src/components/Questions/SCQArray/SCQIconArray.jsx
+++ b/src/components/Questions/SCQArray/SCQIconArray.jsx
@@ -18,11 +18,10 @@ import Content from "~/components/run/Content";
 function SCQIconArray(props) {
   const theme = useTheme();
   const width = useColumnMinWidth();
+  const answers = props.component.answers || [];
 
-  let columns = props.component.answers.filter(
-    (answer) => answer.type == "column"
-  );
-  let rows = props.component.answers.filter((answer) => answer.type == "row");
+  let columns = answers.filter((answer) => answer.type == "column");
+  let rows = answers.filter((answer) => answer.type == "row");
 
   return (
     <TableContainer

--- a/src/components/Questions/Scq/Scq.jsx
+++ b/src/components/Questions/Scq/Scq.jsx
@@ -35,7 +35,7 @@ function SCQ(props) {
         value={state.value}
         onChange={handleChange}
       >
-        {props.component.answers.map((option) => {
+        {(props.component.answers || []).map((option) => {
           if (option.type === "other") {
             return (
               <ScqChoiceOther


### PR DESCRIPTION
## Summary
Choice-type renderers (multiple_text, mcq, scq, icon/image variants, ranking, arrays) called `.map`/`.filter` on `props.component.answers` without a guard, crashing when the backend omitted the field for a question with no rows. Default answers to `[]` across all 11 renderers.

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Trigger the previously-known crash path (a choice-type question whose answers field is undefined); confirm it no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)