### PR TITLE
feat: confirm choice option deletion with a modal

### DIFF
--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -27,6 +27,8 @@ import { setupOptions } from "~/constants/design";
 import { Build } from "@mui/icons-material";
 import ContentEditor from "~/components/design/ContentEditor";
 import InlineCodeEditor from "~/components/design/InlineCodeEditor";
+import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 
 function IconChoiceItemDesign({
   parentCode,
@@ -47,6 +49,7 @@ function IconChoiceItemDesign({
   const ref = useRef(null);
   const theme = useTheme();
   const [iconSelectoOpen, setIconSelectorOpen] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
 
   const answer = useSelector((state) => {
@@ -67,9 +70,12 @@ function IconChoiceItemDesign({
     type == "add" ? undefined : answer.content?.[langInfo.mainLang]?.["label"];
 
   const onDelete = () => {
-    if (window.confirm(t("are_you_sure"))) {
-      dispatch(removeAnswer(qualifiedCode));
-    }
+    setConfirmDeleteOpen(true);
+  };
+
+  const onConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    dispatch(removeAnswer(qualifiedCode));
   };
 
   const isInSetup = useSelector((state) => {
@@ -341,6 +347,18 @@ function IconChoiceItemDesign({
             setIconSelectorOpen(false);
           }}
         />
+      )}
+      {confirmDeleteOpen && (
+        <AppThemeProvider>
+          <ConfirmActionModal
+            open
+            onClose={() => setConfirmDeleteOpen(false)}
+            onConfirm={onConfirmDelete}
+            title={t("are_you_sure")}
+            cancelLabel={t("cancel")}
+            confirmLabel={t("delete")}
+          />
+        </AppThemeProvider>
       )}
     </>
   );

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -26,6 +26,8 @@ import { Build } from "@mui/icons-material";
 import { setupOptions } from "~/constants/design";
 import ContentEditor from "~/components/design/ContentEditor";
 import InlineCodeEditor from "~/components/design/InlineCodeEditor";
+import ConfirmActionModal from "~/components/common/ConfirmActionModal";
+import AppThemeProvider from "~/theme";
 
 function ImageChoiceItemDesign({
   parentCode,
@@ -46,6 +48,7 @@ function ImageChoiceItemDesign({
   const theme = useTheme();
   const ref = useRef();
   const [isUploading, setUploading] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const answer = useSelector((state) => {
     return type == "add" ? undefined : state.designState[qualifiedCode];
@@ -69,9 +72,12 @@ function ImageChoiceItemDesign({
   });
 
   const onDelete = () => {
-    if (window.confirm(t("are_you_sure"))) {
-      dispatch(removeAnswer(qualifiedCode));
-    }
+    setConfirmDeleteOpen(true);
+  };
+
+  const onConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    dispatch(removeAnswer(qualifiedCode));
   };
 
   const isInSetup = useSelector((state) => {
@@ -342,6 +348,18 @@ function ImageChoiceItemDesign({
           />
         )}
       </Grid>
+      {confirmDeleteOpen && (
+        <AppThemeProvider>
+          <ConfirmActionModal
+            open
+            onClose={() => setConfirmDeleteOpen(false)}
+            onConfirm={onConfirmDelete}
+            title={t("are_you_sure")}
+            cancelLabel={t("cancel")}
+            confirmLabel={t("delete")}
+          />
+        </AppThemeProvider>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
Replace the native `window.confirm` in the image/icon choice item delete action with the shared ConfirmActionModal.

The modal is wrapped in the app ThemeProvider so it renders with the admin theme rather than the survey's theme — otherwise the Cancel button's text color is invisible against the modal's white background.

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Click delete on an image-choice option; confirm modal appears
- [ ] Click delete on an icon-choice option; confirm modal appears
- [ ] Confirm modal copy reads correctly in at least 2 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)