### PR TITLE
style: themed design error alerts

### DIFF
--- a/src/components/design/ErrorDisplay/ErrorDisplay.module.css
+++ b/src/components/design/ErrorDisplay/ErrorDisplay.module.css
@@ -2,32 +2,62 @@
   margin: 8px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
+/*
+ * Errors are intentionally styled independently of the survey theme so they
+ * stay legible on any survey background (dark, branded, high-saturation, etc.).
+ * Visuals follow MUI's standard Alert (severity=error, filled-tint) look.
+ */
 .errorItem {
-  border: 1px solid orange;
-  background-color: rgba(255, 166, 0, 0.13);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px 16px;
   border-radius: 4px;
-  padding: 8px;
+  background-color: #fdeded;
+  color: #5f2120;
+  font-size: 0.875rem;
+  line-height: 1.43;
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.08),
+    0 4px 12px rgba(15, 23, 42, 0.1);
+}
+
+.errorItem > svg {
+  color: #d32f2f;
+  font-size: 22px;
+  flex-shrink: 0;
 }
 
 .clickable {
   cursor: pointer;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.clickable:hover {
+  background-color: #fbdcdc;
+  box-shadow:
+    0 2px 4px rgba(15, 23, 42, 0.1),
+    0 8px 18px rgba(15, 23, 42, 0.14);
 }
 
 .errorCode {
   display: inline-block;
-  font-family: monospace;
-  font-size: 0.7rem;
-  background-color: rgba(0, 0, 0, 0.08);
-  border-radius: 3px;
-  padding: 1px 5px;
-  margin-inline-end: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background-color: rgba(211, 47, 47, 0.12);
+  color: #b91c1c;
+  border-radius: 4px;
+  padding: 2px 6px;
   vertical-align: middle;
   letter-spacing: 0.03em;
 }
 
 .errorMessage {
   vertical-align: middle;
+  color: #5f2120;
 }


### PR DESCRIPTION
## Summary
Switch ErrorDisplay items to a fixed MUI Alert (severity=error) look with soft elevation so validation errors stay legible on any survey background instead of inheriting the survey's error palette and blending in.

Note: the fixed red palette is intentional — this PR deliberately makes the alerts *not* theme-aware so they stand out on any survey paper color.

## Context
Part of the PR #236 split. This is one of ~11 small PRs replacing the bundled theme-contrast-colors PR.

## Test plan
- [ ] Introduce a design validation error (e.g. malformed regex); confirm the alert is restyled and stays readable
- [ ] Verify legibility on a dark survey paper color

🤖 Generated with [Claude Code](https://claude.com/claude-code)