### PR TITLE
fix: hover wash and action-icon contrast on dark survey papers

### DIFF
--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -6,7 +6,10 @@ import {
   getForegroundColor,
   getMildBorderColor,
 } from "~/components/Questions/utils";
-import { placeholderImageUrl } from "~/components/Questions/placeholderImage";
+import {
+  placeholderImageUrl,
+  placeholderTileColor,
+} from "~/components/Questions/placeholderImage";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
@@ -91,6 +94,10 @@ function ImageChoiceItemDesign({
   const labelColor = theme.contrast?.onDefault || getForegroundColor(theme.palette.background.default);
   const addCardBorder = theme.contrast?.mildPaperBorder || getMildBorderColor(getContrastColor(theme.palette.background.paper), 0.4);
   const addIconColor = theme.contrast?.onPaper || getForegroundColor(theme.palette.background.paper);
+  // Action icons sit on top of the placeholder tile, not the paper itself.
+  // On dark papers the tile flips to near-white, so `onPaper` (also near-white)
+  // would be invisible. Derive the icon color from the tile we actually paint.
+  const buttonIconColor = getForegroundColor(placeholderTileColor(theme));
 
   const backgroundImage = answer?.resources?.image
     ? `url('${buildResourceUrl(answer.resources.image)}')`
@@ -236,7 +243,11 @@ function ImageChoiceItemDesign({
         cursor: "pointer",
       }}
     >
-      <IconButton className={styles.addAnswerIcon} sx={{ color: addIconColor }}>
+      <IconButton
+        className={styles.addAnswerIcon}
+        disableRipple
+        sx={{ color: addIconColor }}
+      >
         <AddIcon />
       </IconButton>
     </Box>
@@ -265,10 +276,13 @@ function ImageChoiceItemDesign({
         data-handler-id={handlerId}
       >
         {inDesign(designMode) && (
-          <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
+          <div
+            className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}
+            style={{ color: buttonIconColor }}
+          >
             <div className={btnStyles.leftZone}>
-              <IconButton ref={drag} className={btnStyles.iconButton}>
-                <DragIndicatorIcon color="action" />
+              <IconButton ref={drag} className={btnStyles.iconButton} color="inherit">
+                <DragIndicatorIcon />
               </IconButton>
               <div className={btnStyles.codeWrapper}>
                 <InlineCodeEditor
@@ -281,6 +295,7 @@ function ImageChoiceItemDesign({
             <div className={btnStyles.rightZone}>
               <IconButton
                 className={btnStyles.iconButton}
+                color="inherit"
                 onClick={(e) => {
                   e.stopPropagation();
                   setDeleteModalOpen(true);
@@ -290,6 +305,7 @@ function ImageChoiceItemDesign({
               </IconButton>
               <IconButton
                 className={btnStyles.iconButton}
+                color="inherit"
                 onClick={(e) => {
                   e.stopPropagation();
                   dispatch(
@@ -305,6 +321,7 @@ function ImageChoiceItemDesign({
               <IconButton
                 component="label"
                 className={btnStyles.iconButton}
+                color="inherit"
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/src/components/Questions/placeholderImage.js
+++ b/src/components/Questions/placeholderImage.js
@@ -67,6 +67,13 @@ export function placeholderImageUrl(theme) {
   return buildImageUrl(paperOf(theme));
 }
 
+// The resolved tile colour painted behind the placeholder artwork. Exported so
+// callers rendering controls on top of the tile can derive a contrasting
+// foreground from the same surface the tile uses, instead of from paper.
+export function placeholderTileColor(theme) {
+  return getContrastColor(paperOf(theme), TILE_CONTRAST);
+}
+
 /**
  * Theme-aware placeholder for empty icon-choice slots, as raw inline SVG
  * markup (injected into the DOM by DynamicSvg). Keeps the original single

--- a/src/components/design/ActionToolbar/index.jsx
+++ b/src/components/design/ActionToolbar/index.jsx
@@ -13,6 +13,7 @@ import { getContrastRatio } from "@mui/material/styles";
 import {
   getContrastColor,
   getForegroundColor,
+  isDarkColor,
 } from "~/components/Questions/utils";
 import CustomTooltip from "~/components/common/Tooltip/Tooltip";
 import { RuleOutlined, VisibilityOff } from "@mui/icons-material";
@@ -151,7 +152,10 @@ function ActionToolbar({ code, isGroup, parentCode, showActions }) {
       "&:hover": {
         backgroundColor:
           theme.contrast?.hoverPaper ||
-          getContrastColor(theme.palette.background.paper, 0.12),
+          getContrastColor(
+            theme.palette.background.paper,
+            isDarkColor(theme.palette.background.paper) ? 0.88 : 0.12,
+          ),
       },
     }),
     [theme]

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -3,6 +3,7 @@ import {
   getContrastColor,
   getForegroundColor,
   getMildBorderColor,
+  isDarkColor,
 } from "~/components/Questions/utils";
 export {
   BG_COLOR, TEXT_COLOR, PRIMARY_COLOR, SECONDARY_COLOR, ERR_COLOR,
@@ -29,8 +30,13 @@ export const defualtTheme = (theme) => {
   const mildPaperBorder = getMildBorderColor(getContrastColor(paperColor), 0.4);
   const mildDefaultBorder = getMildBorderColor(getContrastColor(bgColor), 0.4);
 
-  // Visible-but-soft hover wash for interactive controls on the card.
-  const hoverPaper = getContrastColor(paperColor, 0.12);
+  // A *subtle* hover wash that always stays close to the paper color.
+  // getContrastColor inverts its opacity arg on dark inputs, so we pass the
+  // complementary value when paper is dark to land on ~12% in both cases.
+  const hoverPaper = getContrastColor(
+    paperColor,
+    isDarkColor(paperColor) ? 0.88 : 0.12,
+  );
 
   return {
     textStyles: {


### PR DESCRIPTION
## Summary
Two related contrast fixes on dark survey paper colors:

- `getContrastColor` flips its opacity arg on dark inputs, so `hoverPaper(0.12)` produced an 88%-white wash on dark papers and matched the white icons. Pass the complementary opacity on dark papers so the wash lands on ~12% in both directions.
- The delete/build/camera/drag icons in image-choice option cards sit on top of the placeholder tile (`getContrastColor(paper, 0.05)`), which flips to near-white on dark papers. Inheriting `onPaper` made them near-white on near-white — invisible. Derive the icon color from the tile colour via a new `placeholderTileColor()` export so the placeholder and its controls share one source of truth.

## Context
Part of the PR #236 split. **Stacked on #245** (feat/design-editor-theme-aware-states) — this PR fixes contrast issues in the theme-aware system introduced by that one.

## Test plan
- [ ] Set the survey paper color to a dark hex (e.g. #1a1a1a); hover over duplicate/delete icons in ActionToolbar and confirm the wash is subtle
- [ ] On the same dark theme, hover over choice/image-choice options; confirm action icons (drag, delete, build, camera) are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)