### PR TITLE
feat: themed DateTime and Time popups

### DIFF
--- a/src/components/Questions/DateTime/DateTimeQuestion.jsx
+++ b/src/components/Questions/DateTime/DateTimeQuestion.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import TextField from "@mui/material/TextField";
 import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -10,13 +10,50 @@ import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 
 import styles from "./DateTimeQuestion.module.css";
-import { useTheme } from "@mui/system";
+import { useTheme, alpha } from "@mui/material/styles";
 import { valueChange } from "~/state/runState";
 import { NAMESPACES } from "~/hooks/useNamespaceLoader";
 
 function DateTimeQuestion(props) {
   const theme = useTheme();
   const { i18n } = useTranslation(NAMESPACES.RUN);
+
+  // Popup styling derived from the survey theme so the picker matches the
+  // surrounding card instead of always rendering on white.
+  const pickerPaperProps = useMemo(() => {
+    const paper = theme.palette.background.paper;
+    const onPaper = theme.contrast?.onPaper;
+    const primary = theme.palette.primary.main;
+    // Hover wash uses the primary color (with alpha) so it stays distinct
+    // from the day-number text — `theme.contrast.hoverPaper` blends in the
+    // same direction as the text and can match it on mid-luminance papers.
+    const hoverBg = alpha(primary, 0.24);
+    return {
+      sx: {
+        backgroundColor: paper,
+        color: onPaper,
+        "& .MuiPickersDay-root": {
+          backgroundColor: "transparent",
+          color: onPaper,
+          "&:hover, &:focus": { backgroundColor: hoverBg, color: onPaper },
+          "&.Mui-selected": {
+            backgroundColor: primary,
+            color: theme.palette.primary.contrastText,
+            "&:hover, &:focus": {
+              backgroundColor: primary,
+              color: theme.palette.primary.contrastText,
+            },
+          },
+        },
+        "& .MuiPickersCalendarHeader-root, & .MuiDayCalendar-weekDayLabel, & .MuiPickersYear-yearButton, & .MuiPickersMonth-monthButton, & .MuiClock-pin, & .MuiClockPointer-root, & .MuiClockNumber-root": {
+          color: onPaper,
+        },
+        "& .MuiPickersYear-yearButton:hover, & .MuiPickersMonth-monthButton:hover": {
+          backgroundColor: hoverBg,
+        },
+      },
+    };
+  }, [theme]);
 
   const state = useSelector((state) => {
     let own = state.runState.values[props.component.qualifiedCode];
@@ -82,14 +119,7 @@ function DateTimeQuestion(props) {
                 " " +
                 (props.component.fullDayFormat ? "HH:mm" : "hh:mm A")
               }
-              PaperProps={{
-                sx: {
-                  backgroundColor: 'white',
-                  "& .MuiPickersDay-root": {
-                    backgroundColor: 'white',
-                  },
-                },
-              }}
+              PaperProps={pickerPaperProps}
 
               ampm={props.component.fullDayFormat ? false : true}
               openTo="year"
@@ -135,14 +165,7 @@ function DateTimeQuestion(props) {
             value={state.value}
             error={state.invalid}
             onChange={handleDateChange}
-            PaperProps={{
-              sx: {
-                backgroundColor: 'white',
-                "& .MuiPickersDay-root": {
-                  backgroundColor: 'white',
-                },
-              },
-            }}
+            PaperProps={pickerPaperProps}
           />
         ) : (
           <DatePicker
@@ -167,14 +190,7 @@ function DateTimeQuestion(props) {
                 )
                 : undefined
             }
-            PaperProps={{
-              sx: {
-                backgroundColor: 'white',
-                "& .MuiPickersDay-root": {
-                  backgroundColor: 'white',
-                },
-              },
-            }}
+            PaperProps={pickerPaperProps}
             maxDate={
               props.component.maxDate
                 ? window.QlarrScripts.dateStringToDate(

--- a/src/components/Questions/DateTime/DateTimeQuestionDesign.jsx
+++ b/src/components/Questions/DateTime/DateTimeQuestionDesign.jsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useMemo } from "react";
 import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
 import styles from "./DateTimeQuestionDesign.module.css";
 import { useSelector } from "react-redux";
 import { useEditableHint } from "~/hooks/useEditableHint";
-import { useTheme } from '@emotion/react';
+import { useTheme } from "@mui/material/styles";
+import Iconify from "~/components/iconify";
+import { getForegroundColor } from "~/components/Questions/utils";
 
 function DateTimeQuestionDesign({ code, designMode }) {
   const state = useSelector((state) => {
@@ -13,6 +16,19 @@ function DateTimeQuestionDesign({ code, designMode }) {
   const theme = useTheme();
 
   const { hintText, isEditable, handleHintChange } = useEditableHint(code, designMode);
+
+  const dateFormat = state.dateFormat || "YYYY/MM/DD";
+  const isDateTime = state.type === "date_time";
+  const sample = isDateTime
+    ? `${dateFormat} ${state.fullDayFormat ? "HH:mm" : "hh:mm A"}`
+    : dateFormat;
+
+  const hintColor = useMemo(
+    () =>
+      theme.contrast?.onPaper ||
+      getForegroundColor(theme.palette.background.paper),
+    [theme]
+  );
 
   return (
     <div className={styles.questionItem}>
@@ -24,9 +40,25 @@ function DateTimeQuestionDesign({ code, designMode }) {
         }
         value={isEditable ? hintText : ""}
         onChange={isEditable ? handleHintChange : undefined}
+        placeholder={sample}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Iconify
+                icon="solar:calendar-minimalistic-linear"
+                width={20}
+                sx={{ color: hintColor }}
+              />
+            </InputAdornment>
+          ),
+        }}
         sx={{
           pointerEvents: isEditable ? "auto" : "none",
-          input: { color: theme.palette.text.disabled },
+          input: { color: hintColor },
+          "& .MuiInputBase-input::placeholder": {
+            color: hintColor,
+            opacity: 0.7,
+          },
         }}
       />
     </div>

--- a/src/components/Questions/DateTime/TimeQuestionDesign.jsx
+++ b/src/components/Questions/DateTime/TimeQuestionDesign.jsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useMemo } from "react";
 import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
 import styles from "./TimeQuestionDesign.module.css";
 import { useSelector } from "react-redux";
 import { useEditableHint } from "~/hooks/useEditableHint";
-import { useTheme } from '@emotion/react';
+import { useTheme } from "@mui/material/styles";
+import Iconify from "~/components/iconify";
+import { getForegroundColor } from "~/components/Questions/utils";
 
 function TimeQuestionDesign({ code, designMode }) {
   const state = useSelector((state) => {
@@ -13,6 +16,15 @@ function TimeQuestionDesign({ code, designMode }) {
   const theme = useTheme();
 
   const { hintText, isEditable, handleHintChange } = useEditableHint(code, designMode);
+
+  const sample = state.fullDayFormat ? "HH:mm" : "hh:mm A";
+
+  const hintColor = useMemo(
+    () =>
+      theme.contrast?.onPaper ||
+      getForegroundColor(theme.palette.background.paper),
+    [theme]
+  );
 
   return (
     <div className={styles.questionItem}>
@@ -24,9 +36,25 @@ function TimeQuestionDesign({ code, designMode }) {
         }
         value={isEditable ? hintText : ""}
         onChange={isEditable ? handleHintChange : undefined}
+        placeholder={sample}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Iconify
+                icon="solar:clock-circle-outline"
+                width={20}
+                sx={{ color: hintColor }}
+              />
+            </InputAdornment>
+          ),
+        }}
         sx={{
           pointerEvents: isEditable ? "auto" : "none",
-          input: { color: theme.palette.text.disabled },
+          input: { color: hintColor },
+          "& .MuiInputBase-input::placeholder": {
+            color: hintColor,
+            opacity: 0.7,
+          },
         }}
       />
     </div>


### PR DESCRIPTION
## Summary
DateTime and Time question popups inherited the MUI default palette regardless of the survey theme. This PR derives popup colors from the survey theme via the new `getForegroundColor` / `theme.contrast` helpers, plus adds a placeholder icon when no date/time is selected.

## Context
Part of the PR #236 split. **Stacked on #245** (feat/design-editor-theme-aware-states) — this PR uses the theme helpers introduced there.

## Test plan
- [ ] Open a DateTime question in design mode; confirm the popup picks up survey theme colors
- [ ] Same for a Time question
- [ ] Confirm the placeholder icon renders when no value is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)