### PR TITLE
feat: revamp survey navigation drawer with progress and cross-group jumps

### DIFF
--- a/public/locales/ar/run.json
+++ b/public/locales/ar/run.json
@@ -12,6 +12,8 @@
   "error": "خطأ",
   "goBack": "العودة إلى الوراء",
   "survey_navigation": "تنقل الاستطلاع",
+  "untitled_question": "(بدون عنوان)",
+  "answered_progress": "{{answered}} / {{total}} تمت الإجابة",
   "processed_errors": {
     "survey_closed": "هذا الاستطلاع غير نشط",
     "survey_design_error": "خطأ في تصميم الاستبيان ... تحقق من تصميم الاستبيان",

--- a/public/locales/de/run.json
+++ b/public/locales/de/run.json
@@ -12,6 +12,8 @@
   "error": "Fehler",
   "goBack": "Zurückgehen",
   "survey_navigation": "Umfragenavigation",
+  "untitled_question": "(Ohne Titel)",
+  "answered_progress": "{{answered}} / {{total}} beantwortet",
   "processed_errors": {
     "survey_closed": "Diese Umfrage ist nicht aktiv",
     "survey_design_error": "Fehler im Umfragedesign... Überprüfen Sie das Umfragedesign",

--- a/public/locales/en/run.json
+++ b/public/locales/en/run.json
@@ -12,6 +12,8 @@
     "error":"Error",
     "goBack":"Go Back",
     "survey_navigation": "Survey Navigation",
+    "untitled_question": "(Untitled)",
+    "answered_progress": "{{answered}} / {{total}} answered",
     "processed_errors": {
         "survey_closed": "This survey is not active",
         "survey_design_error": "Survey Design Error... Check Survey Design",

--- a/public/locales/es/run.json
+++ b/public/locales/es/run.json
@@ -12,6 +12,8 @@
     "error":"Error",
     "goBack":"Volver",
     "survey_navigation": "Navegación de la Encuesta",
+    "untitled_question": "(Sin título)",
+    "answered_progress": "{{answered}} / {{total}} respondidas",
     "processed_errors": {
         "survey_closed": "Esta encuesta no está activa",
         "survey_design_error": "Error de Diseño de Encuesta... Verifica el Diseño de la Encuesta",

--- a/public/locales/fr/run.json
+++ b/public/locales/fr/run.json
@@ -12,6 +12,8 @@
     "error":"Erreur",
     "goBack":"Retour",
     "survey_navigation": "Navigation du Sondage",
+    "untitled_question": "(Sans titre)",
+    "answered_progress": "{{answered}} / {{total}} répondues",
     "processed_errors": {
         "survey_closed": "Ce sondage n'est pas actif",
         "survey_design_error": "Erreur de Conception de Sondage... Vérifiez la Conception du Sondage",

--- a/public/locales/nl/run.json
+++ b/public/locales/nl/run.json
@@ -12,6 +12,8 @@
     "error":"Fout",
     "goBack":"Terug",
     "survey_navigation": "Enquête Navigatie",
+    "untitled_question": "(Zonder titel)",
+    "answered_progress": "{{answered}} / {{total}} beantwoord",
     "processed_errors": {
         "survey_closed": "Deze enquête is niet actief",
         "survey_design_error": "Enquête Ontwerp Fout... Controleer Enquête Ontwerp",

--- a/public/locales/pt/run.json
+++ b/public/locales/pt/run.json
@@ -12,6 +12,8 @@
     "error":"Erro",
     "goBack":"Voltar",
     "survey_navigation": "Navegação da Pesquisa",
+    "untitled_question": "(Sem título)",
+    "answered_progress": "{{answered}} / {{total}} respondidas",
     "processed_errors": {
         "survey_closed": "Esta pesquisa não está ativa",
         "survey_design_error": "Erro de Design de Pesquisa... Verifique o Design da Pesquisa",

--- a/src/components/Question/index.jsx
+++ b/src/components/Question/index.jsx
@@ -345,7 +345,7 @@ const QuestionWrapper = React.memo((props) => {
 
   return (
     <Box
-      data-code={props.code}
+      data-code={props.qualifiedCode}
       css={css`
         ${replaceFormatInstructions(props.customCss, formatState, "custom_css")}
       `}

--- a/src/components/run/Navigation/index.jsx
+++ b/src/components/run/Navigation/index.jsx
@@ -88,7 +88,7 @@ function Navigation(props) {
 
 export default Navigation;
 
-function getClosestScrollableParent(element) {
+export function getClosestScrollableParent(element) {
   if (!element) return null;
 
   let parent = element.parentElement;

--- a/src/components/run/SurveyDrawer/SurveyDrawer.module.css
+++ b/src/components/run/SurveyDrawer/SurveyDrawer.module.css
@@ -1,13 +1,48 @@
 .drawer {
-  padding-top: max(16px, var(--safe-area-inset-top));
-  padding-right: max(16px, var(--safe-area-inset-right));
+  padding-top: max(12px, var(--safe-area-inset-top));
+  padding-right: max(8px, var(--safe-area-inset-right));
   padding-bottom: max(16px, var(--safe-area-inset-bottom));
-  padding-left: max(16px, var(--safe-area-inset-left));
+  padding-left: max(8px, var(--safe-area-inset-left));
+  color: var(--qlarr-on-paper);
 }
 
 .drawerHeader {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid #e0e0e0;
+  gap: 8px;
+  padding: 4px 8px 12px;
+  border-bottom: 1px solid var(--qlarr-mild-border);
+  margin-bottom: 8px;
+}
+
+.drawerHeaderText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.drawerTitle {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--qlarr-on-paper);
+}
+
+.drawerSubtitle {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--qlarr-on-paper);
+  opacity: 0.6;
+}
+
+.closeButton {
+  flex: 0 0 auto;
+  color: var(--qlarr-on-paper) !important;
+}
+
+.closeButton:hover {
+  background-color: var(--qlarr-hover-paper) !important;
 }

--- a/src/components/run/SurveyDrawer/index.jsx
+++ b/src/components/run/SurveyDrawer/index.jsx
@@ -1,17 +1,63 @@
-import { Drawer, IconButton, Typography } from "@mui/material";
+import { Drawer, IconButton } from "@mui/material";
 import styles from "./SurveyDrawer.module.css";
 import SurveyIndex from "~/components/run/SurveyIndex";
-import React from "react";
+import React, { useMemo } from "react";
 import { shallowEqual, useSelector } from "react-redux";
 import { Close } from "@mui/icons-material";
+import { useTheme } from "@emotion/react";
+import { getForegroundColor } from "~/components/Questions/utils";
 
 function SurveyDrawer({ expanded, toggleDrawer, t }) {
+  const theme = useTheme();
+
   const navigationIndex = useSelector((state) => {
     return state.runState.data?.navigationIndex;
   }, shallowEqual);
   const survey = useSelector((state) => {
     return state.runState.data?.survey;
   }, shallowEqual);
+  const relevanceMap = useSelector((state) => {
+    return state.runState.values["Survey"].relevance_map;
+  }, shallowEqual);
+  const surveyValues = useSelector((state) => {
+    return state.runState.values;
+  }, shallowEqual);
+
+  const { answeredCount, totalCount } = useMemo(() => {
+    if (!survey?.groups) return { answeredCount: 0, totalCount: 0 };
+    let total = 0;
+    let answered = 0;
+    for (const group of survey.groups) {
+      if (group.groupType === "END") continue;
+      if (!relevanceMap[group.code]) continue;
+      for (const question of group.questions || []) {
+        if (!relevanceMap[question.code]) continue;
+        total += 1;
+        if (surveyValues[question.code]?.value !== undefined) {
+          answered += 1;
+        }
+      }
+    }
+    return { answeredCount: answered, totalCount: total };
+  }, [survey, relevanceMap, surveyValues]);
+
+  const onPaper =
+    theme.contrast?.onPaper ||
+    getForegroundColor(theme.palette.background.paper);
+  const hoverPaper =
+    theme.contrast?.hoverPaper || theme.palette.action?.hover || "transparent";
+  const mildBorder =
+    theme.contrast?.mildPaperBorder ||
+    theme.palette.divider ||
+    "rgba(0,0,0,0.12)";
+
+  const cssVars = {
+    "--qlarr-on-paper": onPaper,
+    "--qlarr-hover-paper": hoverPaper,
+    "--qlarr-mild-border": mildBorder,
+    "--qlarr-error": theme.palette.error?.main || "#d32f2f",
+    "--qlarr-primary": theme.palette.primary?.main || onPaper,
+  };
 
   return (
     <Drawer
@@ -29,19 +75,35 @@ function SurveyDrawer({ expanded, toggleDrawer, t }) {
         },
       }}
     >
-      <div className={styles.drawer}>
+      <div className={styles.drawer} style={cssVars}>
         <div className={styles.drawerHeader}>
-          <Typography variant="h6" className={styles.drawerTitle}>
-            {t("survey_navigation")}
-          </Typography>
+          <div className={styles.drawerHeaderText}>
+            <span className={styles.drawerTitle}>
+              {t("survey_navigation")}
+            </span>
+            {totalCount > 0 && (
+              <span className={styles.drawerSubtitle}>
+                {t("answered_progress", {
+                  answered: answeredCount,
+                  total: totalCount,
+                })}
+              </span>
+            )}
+          </div>
           <IconButton
             className={styles.closeButton}
             onClick={toggleDrawer(false)}
+            size="small"
+            aria-label="close"
           >
-            <Close />
+            <Close fontSize="small" />
           </IconButton>
         </div>
-        <SurveyIndex navigationIndex={navigationIndex} survey={survey} />
+        <SurveyIndex
+          navigationIndex={navigationIndex}
+          survey={survey}
+          t={t}
+        />
       </div>
     </Drawer>
   );

--- a/src/components/run/SurveyDrawer/index.jsx
+++ b/src/components/run/SurveyDrawer/index.jsx
@@ -7,7 +7,7 @@ import { Close } from "@mui/icons-material";
 import { useTheme } from "@emotion/react";
 import { getForegroundColor } from "~/components/Questions/utils";
 
-function SurveyDrawer({ expanded, toggleDrawer, t }) {
+function SurveyDrawer({ expanded, toggleDrawer, t, onPendingScrollTarget }) {
   const theme = useTheme();
 
   const navigationIndex = useSelector((state) => {
@@ -103,6 +103,8 @@ function SurveyDrawer({ expanded, toggleDrawer, t }) {
           navigationIndex={navigationIndex}
           survey={survey}
           t={t}
+          onCloseDrawer={toggleDrawer(false)}
+          onPendingScrollTarget={onPendingScrollTarget}
         />
       </div>
     </Drawer>

--- a/src/components/run/SurveyIndex/SurveyIndex.module.css
+++ b/src/components/run/SurveyIndex/SurveyIndex.module.css
@@ -1,39 +1,132 @@
-.groupCard {
-  padding: 8px;
-  margin: 8px;
-}
-
-.groupTitle {
-  font-weight: bolder;
-}
-
-.questionTitle {
+.list {
   display: flex;
-  padding: 8px;
-  margin: 8px;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 4px;
 }
 
-.questionIcon {
-  margin-left: 8px;
-  margin-right: 8px;
-  font-size: 1.2rem;
+.groupSection {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 0 10px;
 }
 
-.bullet {
-  margin-right: 8px;
-  margin-left: 8px;
-  font-size: 1.2rem;
+.groupSection + .groupSection {
+  border-top: 1px solid var(--qlarr-mild-border);
+  margin-top: 2px;
+  padding-top: 12px;
 }
 
-.redAsterix {
-  margin-left: 0.5rem;
-  color: red;
+.groupHeader {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--qlarr-on-paper);
+  opacity: 0.6;
+  padding: 4px 12px 8px;
+  user-select: none;
 }
 
-.truncatedTwoLines {
+.groupHeader[data-clickable="true"] {
+  cursor: pointer;
+}
+
+.groupHeader[data-clickable="true"]:hover {
+  opacity: 0.85;
+}
+
+.groupHeader[data-current="true"] {
+  opacity: 0.95;
+  color: var(--qlarr-primary);
+}
+
+.questionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.questionRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px 1fr 20px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  color: var(--qlarr-on-paper);
+  cursor: default;
+  transition: background-color 120ms ease;
+}
+
+.questionRow[data-clickable="true"] {
+  cursor: pointer;
+}
+
+.questionRow[data-clickable="true"]:hover {
+  background-color: var(--qlarr-hover-paper);
+}
+
+.questionRow[data-state="current"] {
+  background-color: var(--qlarr-hover-paper);
+}
+
+.iconTile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background-color: var(--qlarr-hover-paper);
+  font-size: 1rem;
+  flex: 0 0 auto;
+}
+
+.questionRow[data-state="current"] .iconTile {
+  background-color: transparent;
+}
+
+.questionLabel {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.questionRow[data-state="current"] .questionLabel {
+  font-weight: 600;
+}
+
+.questionLabel[data-empty="true"] {
+  font-style: italic;
+  opacity: 0.5;
+}
+
+.statusSlot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: 1.125rem;
+  flex: 0 0 auto;
+}
+
+.statusIcon[data-status="invalid"] {
+  color: var(--qlarr-error);
+}
+
+.statusIcon[data-status="answered"] {
+  color: var(--qlarr-on-paper);
+  opacity: 0.55;
 }

--- a/src/components/run/SurveyIndex/SurveyIndex.module.css
+++ b/src/components/run/SurveyIndex/SurveyIndex.module.css
@@ -1,40 +1,148 @@
-.groupCard {
-  padding: 8px;
-  margin: 8px;
-}
-
-.groupTitle {
-  font-weight: bolder;
-}
-
-.questionTitle {
+.list {
   display: flex;
-  padding: 8px;
-  margin: 8px;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 4px;
 }
 
-.questionIcon {
-  margin-left: 8px;
-  margin-right: 8px;
-  color: green;
-  font-size: 1.2rem;
+.groupSection {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 0 10px;
 }
 
-.bullet {
-  margin-right: 8px;
-  margin-left: 8px;
-  font-size: 1.2rem;
+.groupSection + .groupSection {
+  border-top: 1px solid var(--qlarr-mild-border);
+  margin-top: 2px;
+  padding-top: 12px;
 }
 
-.redAsterix {
-  margin-left: 0.5rem;
-  color: red;
+.groupHeader {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--qlarr-on-paper);
+  opacity: 0.6;
+  padding: 4px 12px 8px;
+  user-select: none;
 }
 
-.truncatedTwoLines {
+.groupHeader[data-clickable="true"] {
+  cursor: pointer;
+}
+
+.groupHeader[data-clickable="true"]:hover {
+  opacity: 0.85;
+}
+
+.groupHeader[data-current="true"] {
+  opacity: 0.95;
+  color: var(--qlarr-primary);
+}
+
+.questionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.questionRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 3px 28px 1fr 20px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px 8px 0;
+  border-radius: 10px;
+  color: var(--qlarr-on-paper);
+  cursor: default;
+  transition: background-color 120ms ease;
+}
+
+.questionRow[data-clickable="true"] {
+  cursor: pointer;
+}
+
+.questionRow[data-clickable="true"]:hover {
+  background-color: var(--qlarr-hover-paper);
+}
+
+.questionRow[data-state="current"] {
+  background-color: var(--qlarr-hover-paper);
+}
+
+.accentBar {
+  display: block;
+  width: 3px;
+  height: 22px;
+  border-radius: 0 3px 3px 0;
+  background-color: transparent;
+}
+
+.questionRow[data-state="current"] .accentBar {
+  background-color: var(--qlarr-primary);
+}
+
+.iconTile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background-color: var(--qlarr-hover-paper);
+  font-size: 1rem;
+  flex: 0 0 auto;
+}
+
+.questionRow[data-state="current"] .iconTile {
+  background-color: transparent;
+}
+
+.questionLabel {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.questionRow[data-state="current"] .questionLabel {
+  font-weight: 600;
+}
+
+.questionLabel[data-empty="true"] {
+  font-style: italic;
+  opacity: 0.5;
+}
+
+.statusSlot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: 1.125rem;
+  flex: 0 0 auto;
+}
+
+.statusIcon[data-status="invalid"] {
+  color: var(--qlarr-error);
+}
+
+.statusIcon[data-status="answered"] {
+  color: var(--qlarr-on-paper);
+  opacity: 0.55;
+}
+
+[dir="rtl"] .accentBar {
+  border-radius: 3px 0 0 3px;
 }

--- a/src/components/run/SurveyIndex/SurveyIndex.module.css
+++ b/src/components/run/SurveyIndex/SurveyIndex.module.css
@@ -1,148 +1,39 @@
-.list {
+.groupCard {
+  padding: 8px;
+  margin: 8px;
+}
+
+.groupTitle {
+  font-weight: bolder;
+}
+
+.questionTitle {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 0 4px;
+  padding: 8px;
+  margin: 8px;
 }
 
-.groupSection {
-  display: flex;
-  flex-direction: column;
-  padding: 6px 0 10px;
+.questionIcon {
+  margin-left: 8px;
+  margin-right: 8px;
+  font-size: 1.2rem;
 }
 
-.groupSection + .groupSection {
-  border-top: 1px solid var(--qlarr-mild-border);
-  margin-top: 2px;
-  padding-top: 12px;
+.bullet {
+  margin-right: 8px;
+  margin-left: 8px;
+  font-size: 1.2rem;
 }
 
-.groupHeader {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--qlarr-on-paper);
-  opacity: 0.6;
-  padding: 4px 12px 8px;
-  user-select: none;
+.redAsterix {
+  margin-left: 0.5rem;
+  color: red;
 }
 
-.groupHeader[data-clickable="true"] {
-  cursor: pointer;
-}
-
-.groupHeader[data-clickable="true"]:hover {
-  opacity: 0.85;
-}
-
-.groupHeader[data-current="true"] {
-  opacity: 0.95;
-  color: var(--qlarr-primary);
-}
-
-.questionList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.questionRow {
-  position: relative;
-  display: grid;
-  grid-template-columns: 3px 28px 1fr 20px;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 12px 8px 0;
-  border-radius: 10px;
-  color: var(--qlarr-on-paper);
-  cursor: default;
-  transition: background-color 120ms ease;
-}
-
-.questionRow[data-clickable="true"] {
-  cursor: pointer;
-}
-
-.questionRow[data-clickable="true"]:hover {
-  background-color: var(--qlarr-hover-paper);
-}
-
-.questionRow[data-state="current"] {
-  background-color: var(--qlarr-hover-paper);
-}
-
-.accentBar {
-  display: block;
-  width: 3px;
-  height: 22px;
-  border-radius: 0 3px 3px 0;
-  background-color: transparent;
-}
-
-.questionRow[data-state="current"] .accentBar {
-  background-color: var(--qlarr-primary);
-}
-
-.iconTile {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  background-color: var(--qlarr-hover-paper);
-  font-size: 1rem;
-  flex: 0 0 auto;
-}
-
-.questionRow[data-state="current"] .iconTile {
-  background-color: transparent;
-}
-
-.questionLabel {
+.truncatedTwoLines {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 0.875rem;
-  line-height: 1.35;
-  min-width: 0;
-  word-break: break-word;
-}
-
-.questionRow[data-state="current"] .questionLabel {
-  font-weight: 600;
-}
-
-.questionLabel[data-empty="true"] {
-  font-style: italic;
-  opacity: 0.5;
-}
-
-.statusSlot {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  font-size: 1.125rem;
-  flex: 0 0 auto;
-}
-
-.statusIcon[data-status="invalid"] {
-  color: var(--qlarr-error);
-}
-
-.statusIcon[data-status="answered"] {
-  color: var(--qlarr-on-paper);
-  opacity: 0.55;
-}
-
-[dir="rtl"] .accentBar {
-  border-radius: 3px 0 0 3px;
 }

--- a/src/components/run/SurveyIndex/index.jsx
+++ b/src/components/run/SurveyIndex/index.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 import styles from "./SurveyIndex.module.css";
+import { Card } from "@mui/material";
+import { Box } from "@mui/system";
 import { stripTags } from "~/utils/design/utils";
 import { shallowEqual, useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
@@ -10,8 +12,6 @@ import {
   questionIconByType,
   getForegroundColor,
 } from "~/components/Questions/utils";
-import CheckCircleOutlineOutlined from "@mui/icons-material/CheckCircleOutlineOutlined";
-import ErrorOutlineOutlined from "@mui/icons-material/ErrorOutlineOutlined";
 
 function SurveyIndex(props) {
   const theme = useTheme();
@@ -20,6 +20,7 @@ function SurveyIndex(props) {
   const iconColor =
     theme.contrast?.onPaper ||
     getForegroundColor(theme.palette.background.paper);
+  const activeBg = theme.contrast?.hoverPaper || theme.palette.action?.hover;
 
   const relevance_map = useSelector((state) => {
     return state.runState.values["Survey"].relevance_map;
@@ -28,20 +29,6 @@ function SurveyIndex(props) {
   const validity_map = useSelector((state) => {
     return state.runState.values["Survey"].validity_map;
   }, shallowEqual);
-
-  const answeredSet = useSelector((state) => {
-    const set = new Set();
-    const values = state.runState.values;
-    for (const code in values) {
-      if (code === "Survey") continue;
-      if (values[code]?.value !== undefined) set.add(code);
-    }
-    return set;
-  }, (a, b) => {
-    if (a.size !== b.size) return false;
-    for (const code of a) if (!b.has(code)) return false;
-    return true;
-  });
 
   const canJump = useSelector((state) => {
     return state.runState.data.navigationData.allowJump;
@@ -83,98 +70,68 @@ function SurveyIndex(props) {
     }
   };
 
-  const questionState = (questionCode) => {
-    if (isCurrentQuestion(questionCode)) return "current";
-    if (validity_map[questionCode] === false) return "invalid";
-    if (answeredSet.has(questionCode)) return "answered";
-    return "pending";
-  };
-
-  const renderStatusIcon = (state) => {
-    if (state === "invalid") {
-      return (
-        <ErrorOutlineOutlined
-          className={styles.statusIcon}
-          fontSize="inherit"
-          data-status="invalid"
-        />
-      );
-    }
-    if (state === "answered") {
-      return (
-        <CheckCircleOutlineOutlined
-          className={styles.statusIcon}
-          fontSize="inherit"
-          data-status="answered"
-        />
-      );
-    }
-    return null;
-  };
-
-  const untitledLabel = props.t ? props.t("untitled_question") : "(Untitled)";
-
-  if (!props.survey?.groups) return null;
-
-  const groups = props.survey.groups.filter(
-    (group) => relevance_map[group.code] && group.groupType != "END",
-  );
-
   return (
-    <div className={styles.list}>
-      {groups.map((group) => {
-        const groupClickable = isGroupClickable(group.code);
-        const groupCurrent = isCurrentGroup(group.code);
-        const groupLabel = stripTags(group.content?.label) || "";
-        return (
-          <section key={group.code} className={styles.groupSection}>
-            {groupLabel && (
-              <div
-                className={styles.groupHeader}
-                data-clickable={groupClickable ? "true" : "false"}
-                data-current={groupCurrent ? "true" : "false"}
-                onClick={() => onGroupClicked(group.code)}
-              >
-                {groupLabel}
-              </div>
-            )}
-            <ul className={styles.questionList}>
-              {group.questions
-                .filter((question) => relevance_map[question.code])
-                .map((question) => {
-                  const state = questionState(question.code);
-                  const clickable = isQuestionClickable(question.code);
-                  const rawLabel = stripTags(question.content?.label) || "";
-                  const labelText = rawLabel.trim();
-                  return (
-                    <li
-                      key={question.code}
-                      className={styles.questionRow}
-                      data-state={state}
-                      data-clickable={clickable ? "true" : "false"}
-                      onClick={() => onQuestionClicked(question.code)}
-                    >
-                      <span className={styles.accentBar} aria-hidden="true" />
-                      <span className={styles.iconTile}>
-                        {questionIconByType(question.type, "1em", iconColor)}
-                      </span>
-                      <span
-                        className={styles.questionLabel}
-                        data-empty={labelText ? "false" : "true"}
-                      >
-                        {labelText || untitledLabel}
-                      </span>
-                      <span className={styles.statusSlot}>
-                        {renderStatusIcon(state)}
-                      </span>
-                    </li>
-                  );
-                })}
-            </ul>
-          </section>
-        );
-      })}
-    </div>
+    <>
+      {props.survey && props.survey.groups
+        ? props.survey.groups
+            .filter(
+              (group) => relevance_map[group.code] && group.groupType != "END"
+            )
+            .map((group) => {
+              return (
+                <Card
+                  onClick={() => onGroupClicked(group.code)}
+                  key={group.code}
+                  className={styles.groupCard}
+                  style={{
+                    backgroundColor: isCurrentGroup(group.code)
+                      ? activeBg
+                      : theme.palette.background.paper,
+                    cursor: isGroupClickable(group.code)
+                      ? "pointer"
+                      : "default",
+                  }}
+                >
+                  <Box className={styles.groupTitle}>
+                    {stripTags(group.content?.label)}{" "}
+                  </Box>
+                  {group.questions
+                    .filter((question) => relevance_map[question.code])
+                    .map((question) => {
+                      return (
+                        <Box
+                          key={question.code}
+                          onClick={() => onQuestionClicked(question.code)}
+                          className={styles.questionTitle}
+                          style={{
+                            backgroundColor: isCurrentQuestion(question.code)
+                              ? activeBg
+                              : "inherit",
+                            cursor: isGroupClickable(group.code)
+                              ? "inherit"
+                              : isQuestionClickable(group.code)
+                              ? "pointer"
+                              : "default",
+                          }}
+                        >
+                          <span className={styles.questionIcon}>
+                            {questionIconByType(question.type, "1.25em", iconColor)}
+                          </span>
+
+                          <span className={styles.truncatedTwoLines}>
+                            {stripTags(question.content?.label)}
+                          </span>
+                          {!validity_map[question.code] && (
+                            <span className={styles.redAsterix}>*</span>
+                          )}
+                        </Box>
+                      );
+                    })}
+                </Card>
+              );
+            })
+        : ""}
+    </>
   );
 }
 

--- a/src/components/run/SurveyIndex/index.jsx
+++ b/src/components/run/SurveyIndex/index.jsx
@@ -1,18 +1,25 @@
 import React from "react";
 
 import styles from "./SurveyIndex.module.css";
-import { Card } from "@mui/material";
-import { Box } from "@mui/system";
 import { stripTags } from "~/utils/design/utils";
 import { shallowEqual, useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
 import { useDispatch } from "react-redux";
 import { jump } from "~/state/runState";
-import { questionIconByType } from "~/components/Questions/utils";
+import {
+  questionIconByType,
+  getForegroundColor,
+} from "~/components/Questions/utils";
+import CheckCircleOutlineOutlined from "@mui/icons-material/CheckCircleOutlineOutlined";
+import ErrorOutlineOutlined from "@mui/icons-material/ErrorOutlineOutlined";
 
 function SurveyIndex(props) {
   const theme = useTheme();
   const dispatch = useDispatch();
+
+  const iconColor =
+    theme.contrast?.onPaper ||
+    getForegroundColor(theme.palette.background.paper);
 
   const relevance_map = useSelector((state) => {
     return state.runState.values["Survey"].relevance_map;
@@ -21,6 +28,20 @@ function SurveyIndex(props) {
   const validity_map = useSelector((state) => {
     return state.runState.values["Survey"].validity_map;
   }, shallowEqual);
+
+  const answeredSet = useSelector((state) => {
+    const set = new Set();
+    const values = state.runState.values;
+    for (const code in values) {
+      if (code === "Survey") continue;
+      if (values[code]?.value !== undefined) set.add(code);
+    }
+    return set;
+  }, (a, b) => {
+    if (a.size !== b.size) return false;
+    for (const code of a) if (!b.has(code)) return false;
+    return true;
+  });
 
   const canJump = useSelector((state) => {
     return state.runState.data.navigationData.allowJump;
@@ -62,68 +83,98 @@ function SurveyIndex(props) {
     }
   };
 
-  return (
-    <>
-      {props.survey && props.survey.groups
-        ? props.survey.groups
-            .filter(
-              (group) => relevance_map[group.code] && group.groupType != "END"
-            )
-            .map((group) => {
-              return (
-                <Card
-                  onClick={() => onGroupClicked(group.code)}
-                  key={group.code}
-                  className={styles.groupCard}
-                  style={{
-                    backgroundColor: isCurrentGroup(group.code)
-                      ? "beige"
-                      : theme.palette.background.paper,
-                    cursor: isGroupClickable(group.code)
-                      ? "pointer"
-                      : "default",
-                  }}
-                >
-                  <Box className={styles.groupTitle}>
-                    {stripTags(group.content?.label)}{" "}
-                  </Box>
-                  {group.questions
-                    .filter((question) => relevance_map[question.code])
-                    .map((question) => {
-                      return (
-                        <Box
-                          key={question.code}
-                          onClick={() => onQuestionClicked(question.code)}
-                          className={styles.questionTitle}
-                          style={{
-                            backgroundColor: isCurrentQuestion(question.code)
-                              ? "beige"
-                              : "inherit",
-                            cursor: isGroupClickable(group.code)
-                              ? "inherit"
-                              : isQuestionClickable(group.code)
-                              ? "pointer"
-                              : "default",
-                          }}
-                        >
-                          <span className={styles.questionIcon}>
-                            {questionIconByType(question.type)}
-                          </span>
+  const questionState = (questionCode) => {
+    if (isCurrentQuestion(questionCode)) return "current";
+    if (validity_map[questionCode] === false) return "invalid";
+    if (answeredSet.has(questionCode)) return "answered";
+    return "pending";
+  };
 
-                          <span className={styles.truncatedTwoLines}>
-                            {stripTags(question.content?.label)}
-                          </span>
-                          {!validity_map[question.code] && (
-                            <span className={styles.redAsterix}>*</span>
-                          )}
-                        </Box>
-                      );
-                    })}
-                </Card>
-              );
-            })
-        : ""}
-    </>
+  const renderStatusIcon = (state) => {
+    if (state === "invalid") {
+      return (
+        <ErrorOutlineOutlined
+          className={styles.statusIcon}
+          fontSize="inherit"
+          data-status="invalid"
+        />
+      );
+    }
+    if (state === "answered") {
+      return (
+        <CheckCircleOutlineOutlined
+          className={styles.statusIcon}
+          fontSize="inherit"
+          data-status="answered"
+        />
+      );
+    }
+    return null;
+  };
+
+  const untitledLabel = props.t ? props.t("untitled_question") : "(Untitled)";
+
+  if (!props.survey?.groups) return null;
+
+  const groups = props.survey.groups.filter(
+    (group) => relevance_map[group.code] && group.groupType != "END",
+  );
+
+  return (
+    <div className={styles.list}>
+      {groups.map((group) => {
+        const groupClickable = isGroupClickable(group.code);
+        const groupCurrent = isCurrentGroup(group.code);
+        const groupLabel = stripTags(group.content?.label) || "";
+        return (
+          <section key={group.code} className={styles.groupSection}>
+            {groupLabel && (
+              <div
+                className={styles.groupHeader}
+                data-clickable={groupClickable ? "true" : "false"}
+                data-current={groupCurrent ? "true" : "false"}
+                onClick={() => onGroupClicked(group.code)}
+              >
+                {groupLabel}
+              </div>
+            )}
+            <ul className={styles.questionList}>
+              {group.questions
+                .filter((question) => relevance_map[question.code])
+                .map((question) => {
+                  const state = questionState(question.code);
+                  const clickable = isQuestionClickable(question.code);
+                  const rawLabel = stripTags(question.content?.label) || "";
+                  const labelText = rawLabel.trim();
+                  return (
+                    <li
+                      key={question.code}
+                      className={styles.questionRow}
+                      data-state={state}
+                      data-clickable={clickable ? "true" : "false"}
+                      onClick={() => onQuestionClicked(question.code)}
+                    >
+                      <span className={styles.accentBar} aria-hidden="true" />
+                      <span className={styles.iconTile}>
+                        {questionIconByType(question.type, "1em", iconColor)}
+                      </span>
+                      <span
+                        className={styles.questionLabel}
+                        data-empty={labelText ? "false" : "true"}
+                      >
+                        {labelText || untitledLabel}
+                      </span>
+                      <span className={styles.statusSlot}>
+                        {renderStatusIcon(state)}
+                      </span>
+                    </li>
+                  );
+                })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/components/run/SurveyIndex/index.jsx
+++ b/src/components/run/SurveyIndex/index.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 
 import styles from "./SurveyIndex.module.css";
-import { Card } from "@mui/material";
-import { Box } from "@mui/system";
 import { stripTags } from "~/utils/design/utils";
 import { shallowEqual, useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
@@ -12,6 +10,9 @@ import {
   questionIconByType,
   getForegroundColor,
 } from "~/components/Questions/utils";
+import CheckCircleOutlineOutlined from "@mui/icons-material/CheckCircleOutlineOutlined";
+import ErrorOutlineOutlined from "@mui/icons-material/ErrorOutlineOutlined";
+import { getClosestScrollableParent } from "~/components/run/Navigation";
 
 function SurveyIndex(props) {
   const theme = useTheme();
@@ -20,7 +21,6 @@ function SurveyIndex(props) {
   const iconColor =
     theme.contrast?.onPaper ||
     getForegroundColor(theme.palette.background.paper);
-  const activeBg = theme.contrast?.hoverPaper || theme.palette.action?.hover;
 
   const relevance_map = useSelector((state) => {
     return state.runState.values["Survey"].relevance_map;
@@ -29,6 +29,20 @@ function SurveyIndex(props) {
   const validity_map = useSelector((state) => {
     return state.runState.values["Survey"].validity_map;
   }, shallowEqual);
+
+  const answeredSet = useSelector((state) => {
+    const set = new Set();
+    const values = state.runState.values;
+    for (const code in values) {
+      if (code === "Survey") continue;
+      if (values[code]?.value !== undefined) set.add(code);
+    }
+    return set;
+  }, (a, b) => {
+    if (a.size !== b.size) return false;
+    for (const code of a) if (!b.has(code)) return false;
+    return true;
+  });
 
   const canJump = useSelector((state) => {
     return state.runState.data.navigationData.allowJump;
@@ -49,89 +63,141 @@ function SurveyIndex(props) {
   };
 
   const isGroupClickable = (groupCode) =>
-    canJump &&
-    !isCurrentGroup(groupCode) &&
-    props.navigationIndex.name == "group";
+    canJump && !isCurrentGroup(groupCode);
 
   const isQuestionClickable = (questionCode) =>
-    canJump &&
-    !isCurrentQuestion(questionCode) &&
-    props.navigationIndex.name == "question";
+    canJump && !isCurrentQuestion(questionCode);
 
-  const onGroupClicked = (groupCode) => {
-    if (isGroupClickable(groupCode)) {
-      dispatch(jump({ ...props.navigationIndex, groupId: groupCode }));
-    }
+  const closeDrawer = () => {
+    if (props.onCloseDrawer) props.onCloseDrawer();
   };
 
-  const onQuestionClicked = (questionCode) => {
-    if (isQuestionClickable(questionCode)) {
+  const scrollToElement = (el) => {
+    const container = getClosestScrollableParent(el);
+    container.scrollTo({
+      top: el.offsetTop - container.offsetTop,
+      behavior: "smooth",
+    });
+  };
+
+  const onGroupClicked = (groupCode) => {
+    if (!isGroupClickable(groupCode)) return;
+    closeDrawer();
+    dispatch(jump({ ...props.navigationIndex, groupId: groupCode }));
+  };
+
+  const onQuestionClicked = (questionCode, groupCode) => {
+    if (!isQuestionClickable(questionCode)) {
+      closeDrawer();
+      return;
+    }
+    closeDrawer();
+    const el = document.querySelector(`[data-code="${questionCode}"]`);
+    if (el) {
+      scrollToElement(el);
+      return;
+    }
+    if (props.onPendingScrollTarget) {
+      props.onPendingScrollTarget(questionCode);
+    }
+    if (props.navigationIndex.name === "group") {
+      dispatch(jump({ ...props.navigationIndex, groupId: groupCode }));
+    } else {
       dispatch(jump({ ...props.navigationIndex, questionId: questionCode }));
     }
   };
 
-  return (
-    <>
-      {props.survey && props.survey.groups
-        ? props.survey.groups
-            .filter(
-              (group) => relevance_map[group.code] && group.groupType != "END"
-            )
-            .map((group) => {
-              return (
-                <Card
-                  onClick={() => onGroupClicked(group.code)}
-                  key={group.code}
-                  className={styles.groupCard}
-                  style={{
-                    backgroundColor: isCurrentGroup(group.code)
-                      ? activeBg
-                      : theme.palette.background.paper,
-                    cursor: isGroupClickable(group.code)
-                      ? "pointer"
-                      : "default",
-                  }}
-                >
-                  <Box className={styles.groupTitle}>
-                    {stripTags(group.content?.label)}{" "}
-                  </Box>
-                  {group.questions
-                    .filter((question) => relevance_map[question.code])
-                    .map((question) => {
-                      return (
-                        <Box
-                          key={question.code}
-                          onClick={() => onQuestionClicked(question.code)}
-                          className={styles.questionTitle}
-                          style={{
-                            backgroundColor: isCurrentQuestion(question.code)
-                              ? activeBg
-                              : "inherit",
-                            cursor: isGroupClickable(group.code)
-                              ? "inherit"
-                              : isQuestionClickable(group.code)
-                              ? "pointer"
-                              : "default",
-                          }}
-                        >
-                          <span className={styles.questionIcon}>
-                            {questionIconByType(question.type, "1.25em", iconColor)}
-                          </span>
+  const questionState = (questionCode) => {
+    if (isCurrentQuestion(questionCode)) return "current";
+    if (validity_map[questionCode] === false) return "invalid";
+    if (answeredSet.has(questionCode)) return "answered";
+    return "pending";
+  };
 
-                          <span className={styles.truncatedTwoLines}>
-                            {stripTags(question.content?.label)}
-                          </span>
-                          {!validity_map[question.code] && (
-                            <span className={styles.redAsterix}>*</span>
-                          )}
-                        </Box>
-                      );
-                    })}
-                </Card>
-              );
-            })
-        : ""}
-    </>
+  const renderStatusIcon = (state) => {
+    if (state === "invalid") {
+      return (
+        <ErrorOutlineOutlined
+          className={styles.statusIcon}
+          fontSize="inherit"
+          data-status="invalid"
+        />
+      );
+    }
+    if (state === "answered") {
+      return (
+        <CheckCircleOutlineOutlined
+          className={styles.statusIcon}
+          fontSize="inherit"
+          data-status="answered"
+        />
+      );
+    }
+    return null;
+  };
+
+  const untitledLabel = props.t ? props.t("untitled_question") : "(Untitled)";
+
+  if (!props.survey?.groups) return null;
+
+  const groups = props.survey.groups.filter(
+    (group) => relevance_map[group.code] && group.groupType != "END",
+  );
+
+  return (
+    <div className={styles.list}>
+      {groups.map((group) => {
+        const groupClickable = isGroupClickable(group.code);
+        const groupCurrent = isCurrentGroup(group.code);
+        const groupLabel = stripTags(group.content?.label) || "";
+        return (
+          <section key={group.code} className={styles.groupSection}>
+            {groupLabel && (
+              <div
+                className={styles.groupHeader}
+                data-clickable={groupClickable ? "true" : "false"}
+                data-current={groupCurrent ? "true" : "false"}
+                onClick={() => onGroupClicked(group.code)}
+              >
+                {groupLabel}
+              </div>
+            )}
+            <ul className={styles.questionList}>
+              {group.questions
+                .filter((question) => relevance_map[question.code])
+                .map((question) => {
+                  const state = questionState(question.code);
+                  const clickable = isQuestionClickable(question.code);
+                  const rawLabel = stripTags(question.content?.label) || "";
+                  const labelText = rawLabel.trim();
+                  return (
+                    <li
+                      key={question.code}
+                      className={styles.questionRow}
+                      data-state={state}
+                      data-clickable={clickable ? "true" : "false"}
+                      onClick={() => onQuestionClicked(question.code, group.code)}
+                    >
+                      <span className={styles.iconTile}>
+                        {questionIconByType(question.type, "1em", iconColor)}
+                      </span>
+                      <span
+                        className={styles.questionLabel}
+                        data-empty={labelText ? "false" : "true"}
+                      >
+                        {labelText || untitledLabel}
+                      </span>
+                      <span className={styles.statusSlot}>
+                        {renderStatusIcon(state)}
+                      </span>
+                    </li>
+                  );
+                })}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/pages/RunSurvey/index.jsx
+++ b/src/pages/RunSurvey/index.jsx
@@ -29,6 +29,7 @@ import RunLoadingDots from "~/components/common/RunLoadingDots";
 
 import SurveyDrawer, { COLLAPSE, EXPAND } from "~/components/run/SurveyDrawer";
 import SurveyAppBar from "~/components/run/SurveyAppBar";
+import { getClosestScrollableParent } from "~/components/run/Navigation";
 import { routes } from "~/routes";
 
 function RunSurvey({
@@ -49,6 +50,7 @@ function RunSurvey({
   const [currentMode, setCurrentMode] = React.useState(mode);
   const [currentNavigationMode, setCurrentNavigationMode] =
     React.useState(navigationMode);
+  const [pendingScrollTarget, setPendingScrollTarget] = React.useState(null);
   const containerRef = useRef(null);
 
   const store = useStore()
@@ -227,10 +229,38 @@ function RunSurvey({
   };
 
   useEffect(() => {
-    if (!navigation && containerRef.current) {
+    if (navigation || !containerRef.current) return;
+    if (!pendingScrollTarget) {
       containerRef.current.scrollTo({ top: 0 });
+      return;
     }
-  }, [navigation, containerRef.current]);
+    const delays = [50, 150, 400];
+    let cancelled = false;
+    const tryScroll = (i) => {
+      if (cancelled) return;
+      const el = document.querySelector(
+        `[data-code="${pendingScrollTarget}"]`,
+      );
+      if (el) {
+        const container = getClosestScrollableParent(el);
+        container.scrollTo({
+          top: el.offsetTop - container.offsetTop,
+          behavior: "smooth",
+        });
+        setPendingScrollTarget(null);
+        return;
+      }
+      if (i >= delays.length) {
+        setPendingScrollTarget(null);
+        return;
+      }
+      setTimeout(() => tryScroll(i + 1), delays[i]);
+    };
+    tryScroll(0);
+    return () => {
+      cancelled = true;
+    };
+  }, [navigation, pendingScrollTarget]);
 
   useEffect(() => {
     document.body.style.overflow = "visible";
@@ -267,7 +297,7 @@ function RunSurvey({
 
   const toggleDrawer = (open) => (event) => {
     if (
-      event.type === "keydown" &&
+      event?.type === "keydown" &&
       (event.key === "Tab" || event.key === "Shift")
     ) {
       return;
@@ -318,6 +348,7 @@ function RunSurvey({
                   expanded={expanded}
                   toggleDrawer={toggleDrawer}
                   t={t}
+                  onPendingScrollTarget={setPendingScrollTarget}
                 />
               </div>
             </>


### PR DESCRIPTION
## Summary
**This is the PR the manager specifically asked to see split out.** Three changes that together rework the navigation drawer:

- **SurveyDrawer**: themed states, answered-progress display in the header, refined close button, paper-color-aware CSS variables
- **SurveyIndex**: semantic list/section layout with status icons (answered / current / invalid / pending); replaces the legacy Card-per-group layout
- **Cross-group jumps**: clicking a question in a different group now jumps you there (was blocked by group-name navigation mode). `toggleDrawer` event guard for keyboard activation
- New i18n keys: `untitled_question`, `answered_progress` in `run.json` (all 7 locales)

Plus a small util export from `Navigation/index.jsx` (`getClosestScrollableParent`) used by the new scroll-to-element logic.

## Context
Part of the PR #236 split. **Stacked on #245** (feat/design-editor-theme-aware-states) — this PR uses the theme helpers introduced there.

## Test plan
- [ ] Run a survey; open the drawer; confirm progress text ("3 of 7 answered" etc.) appears in the header
- [ ] Confirm status icons next to each question reflect answered/current/invalid state
- [ ] Click a question in a different group; confirm you jump there
- [ ] Verify themed appearance on a dark survey paper color

🤖 Generated with [Claude Code](https://claude.com/claude-code)