### PR TITLE
fix: apply custom CSS to groups

### DIFF
--- a/src/components/Group/GroupDesign.jsx
+++ b/src/components/Group/GroupDesign.jsx
@@ -4,7 +4,7 @@ import styles from "./GroupDesign.module.css";
 import { useSelector } from "react-redux";
 import { QuestionDropArea } from "../design/DropArea/DropArea";
 import GroupHeader from "./GroupHeader";
-import { Box, Divider, decomposeColor, recomposeColor } from "@mui/material";
+import { Box, Divider, css, decomposeColor, recomposeColor } from "@mui/material";
 import { useDrag, useDrop } from "react-dnd";
 import { useTheme } from "@emotion/react";
 import { useDispatch } from "react-redux";
@@ -156,6 +156,9 @@ function GroupDesign({ t, code, index, designMode, lastAddedComponent, isLastGro
       className={`${styles.topLevel} ${isLastAdded ? styles.highlight : ""}`}
       ref={containerRef}
       style={getStyles(isDragging)}
+      css={css`
+        ${group.customCss || ""}
+      `}
     >
       <GroupHeader
         t={t}

--- a/src/components/Group/index.jsx
+++ b/src/components/Group/index.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import { useSelector, shallowEqual } from "react-redux";
 
 import Question from "~/components/Question";
-import Content from "~/components/run/Content";
+import Content, { replaceFormatInstructions } from "~/components/run/Content";
 
 import styles from "./Group.module.css";
-import { Box, Divider, useTheme } from "@mui/material";
+import { Box, css, Divider, useTheme } from "@mui/material";
 
 function Group(props) {
   const theme = useTheme();
@@ -17,6 +17,10 @@ function Group(props) {
         typeof groupState?.relevance === "undefined" || groupState.relevance,
     };
   }, shallowEqual);
+
+  const formatState = useSelector((state) => {
+    return state.runState.values[props.group.code];
+  });
 
   const visibleQuestionCodes = useSelector((state) => {
     return (props.group?.questions ?? [])
@@ -39,6 +43,9 @@ function Group(props) {
           boxShadow: "0 4px 20px rgba(22, 32, 91, 0.08)",
           backgroundColor: theme.palette.background.paper,
         }}
+        css={css`
+          ${replaceFormatInstructions(props.group.customCss, formatState, "custom_css")}
+        `}
       >
         <div className={styles.groupHeader}>
           <Content


### PR DESCRIPTION
## Summary
- The **Custom Style** textarea on a group's Design tab was saved to Redux but never applied to the rendered group — both in the design canvas and in survey run mode.
- Mirrors the existing Question pattern: inject `customCss` via emotion's `css` prop on the outer `<Box>`.
- Runtime path goes through `replaceFormatInstructions` (same helper `QuestionWrapper` uses) so format instructions resolve correctly against the group's run state.

## Test plan
- [ ] `npm start`, open a survey, click a group header → Design tab.
- [ ] Enter `background-color: blue;` in Custom Style → group container in the canvas turns blue.
- [ ] Try `border: 2px dashed red; padding: 24px;` → both apply.
- [ ] Clear the textarea → group reverts to default styling.
- [ ] Open Preview → custom CSS applies to the group in run mode.
- [ ] Regression: edit a Question's custom CSS → still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)