### PR TITLE
fix: align logic builder date pickers with installed v5 API

### DIFF
--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateInput.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { DATE_FORMATS } from '../../config/constants';
@@ -18,10 +19,8 @@ export const DateInput = React.memo(function DateInput({ value, onChange, t, com
       onChange={(newValue) => {
         onChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
       }}
-      slotProps={{
-        textField: textFieldProps,
-      }}
-      format={DATE_FORMATS.DATE_DISPLAY}
+      inputFormat={DATE_FORMATS.DATE_DISPLAY}
+      renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );
 });

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateTimeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateTimeInput.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { DATE_FORMATS } from '../../config/constants';
@@ -18,10 +19,8 @@ export const DateTimeInput = React.memo(function DateTimeInput({ value, onChange
       onChange={(newValue) => {
         onChange(newValue ? newValue.format(DATE_FORMATS.DATETIME_VALUE) : '');
       }}
-      slotProps={{
-        textField: textFieldProps,
-      }}
-      format={DATE_FORMATS.DATETIME_DISPLAY}
+      inputFormat={DATE_FORMATS.DATETIME_DISPLAY}
+      renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );
 });

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
@@ -82,14 +82,15 @@ export const RangeInput = React.memo(function RangeInput({ fieldType, value, onC
             onChange={(newValue) => {
               handleMinChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
             }}
-            slotProps={{
-              textField: {
-                ...fromProps,
-                sx: { ...fromProps.sx, flex: 1, minWidth: 0 },
-                error: inverted,
-              },
-            }}
-            format={DATE_FORMATS.DATE_DISPLAY}
+            inputFormat={DATE_FORMATS.DATE_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...fromProps}
+                sx={{ ...fromProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
           />
           <span className={styles.rangeSeparator}>-</span>
           <DatePicker
@@ -98,14 +99,15 @@ export const RangeInput = React.memo(function RangeInput({ fieldType, value, onC
             onChange={(newValue) => {
               handleMaxChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
             }}
-            slotProps={{
-              textField: {
-                ...toProps,
-                sx: { ...toProps.sx, flex: 1, minWidth: 0 },
-                error: inverted,
-              },
-            }}
-            format={DATE_FORMATS.DATE_DISPLAY}
+            inputFormat={DATE_FORMATS.DATE_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...toProps}
+                sx={{ ...toProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
           />
         </div>
         {errorElement}

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/TimeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/TimeInput.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { TextField } from '@mui/material';
 import { TimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { DATE_FORMATS } from '../../config/constants';
@@ -18,10 +19,8 @@ export const TimeInput = React.memo(function TimeInput({ value, onChange, t, com
       onChange={(newValue) => {
         onChange(newValue ? newValue.format(DATE_FORMATS.TIME_VALUE) : '');
       }}
-      slotProps={{
-        textField: textFieldProps,
-      }}
-      format={DATE_FORMATS.TIME_DISPLAY}
+      inputFormat={DATE_FORMATS.TIME_DISPLAY}
+      renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );
 });


### PR DESCRIPTION
## Summary
- The four `ValueInput` pickers in `QlarrLogicBuilder` (`DateInput`, `DateTimeInput`, `TimeInput`, and the date branch of `RangeInput`) were written against `@mui/x-date-pickers` v6 (`slotProps`, `format`), but the installed package is v5.0.20. As soon as the user selected a date-typed field in the Relevance / Skip Logic panel, v5's internal `KeyboardDateInput` blew up with `TypeError: renderInput is not a function`.
- Swap each picker over to the v5 API (`renderInput` + `inputFormat`), matching the working v5 usages already in the codebase ([`DateTimeQuestion`](src/components/Questions/DateTime/DateTimeQuestion.jsx), [`SurveyActiveFromTo`](src/components/SurveyActiveFromTo/index.jsx)). The `textFieldProps` from `getCompactTextFieldProps` are spread onto the `<TextField {...params} {...textFieldProps} />` returned by `renderInput`, preserving compact-mode styling. In `RangeInput`, the per-instance `sx`/`error` overrides layer on top, as they did inside the previous `slotProps.textField` object.
- No package, `LocalizationProvider`, or other-component changes needed.

## Test plan
- [ ] `npm start`, open a survey in the Design page.
- [ ] Open the Relevance (Skip Logic) panel for any question and add a condition that targets each of: a `date` field, a `date_time` field, a `time` field. Each picker should render and accept a value, with no console error.
- [ ] Add a between/range condition on a date field — verify both "from" and "to" pickers render and the inversion error message still appears when from > to.
- [ ] Confirm existing v5 usages still work: Survey settings → "Active from / Active to" pickers, and running a survey with date / time / date_time questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)