### PR TITLE
fix: consistent add-answer button height for icon/image choice

### DIFF
--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -42,6 +42,9 @@ function IconChoiceItemDesign({
   t,
   addAnswer,
 }) {
+  // Fixed icon-cell height so the "+" never stretches and roughly matches a typical
+  // cell (action-button row + icon + one label line; less when the label is hidden).
+  const cellHeight = imageHeight + (hideText ? 52 : 80);
   const designService = useService("design");
   const dispatch = useDispatch();
   const ref = useRef(null);
@@ -204,25 +207,20 @@ function IconChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid item xs={12 / columnNumber} height="100%" key="add">
+    <Grid item xs={12 / columnNumber} key="add">
       <Box
         className={styles.addAnswerButton}
+        onClick={() => {
+          addAnswer();
+        }}
         style={{
-          minHeight: "100px",
+          height: cellHeight + "px",
           borderRadius: "4px",
           backgroundColor: theme.palette.background.default,
-          height: "100%",
           width: "100%",
         }}
       >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
-          }}
-        >
-          <AddIcon />
-        </IconButton>
+        <AddIcon className={styles.addAnswerIcon} color="action" />
       </Box>
     </Grid>
   ) : (
@@ -230,6 +228,7 @@ function IconChoiceItemDesign({
       <Grid
         style={{
           opacity: isDragging ? "0.2" : "1",
+          minHeight: cellHeight + "px",
         }}
         item
         data-code={code}

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.module.css
@@ -1,3 +1,11 @@
+.imageContainer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
 .addAnswerIcon {
   scale: 2;
 }
@@ -23,6 +31,7 @@
   justify-content: center;
   text-align: center;
   vertical-align: middle;
+  cursor: pointer;
 }
 
 .svgContainer > svg {

--- a/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceDesign.jsx
@@ -41,6 +41,7 @@ function ImageChoiceQuestion(props) {
           sx={{
             display: "flex",
             flexWrap: "wrap",
+            alignItems: "flex-start",
             gap: `${spacing}px`,
           }}
         >

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -210,25 +210,31 @@ function ImageChoiceItemDesign({
   drop(preview(ref));
 
   return type == "add" ? (
-    <Grid height="100%" item xs={12 / columnNumber} key="add">
+    <Grid item xs={12 / columnNumber} key="add">
       <Box
         className={styles.addAnswerButton}
+        onClick={() => {
+          addAnswer();
+        }}
         style={{
-          minHeight: "100px",
-          height: "100%",
+          position: "relative",
           width: "100%",
+          paddingTop: 100 / imageAspectRatio + "%",
           backgroundColor: theme.palette.background.default,
           borderRadius: "4px",
         }}
       >
-        <IconButton
-          className={styles.addAnswerIcon}
-          onClick={() => {
-            addAnswer();
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
           }}
         >
-          <AddIcon />
-        </IconButton>
+          <AddIcon className={styles.addAnswerIcon} color="action" />
+        </div>
       </Box>
     </Grid>
   ) : (

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
@@ -35,4 +35,5 @@
   justify-content: center;
   text-align: center;
   vertical-align: middle;
+  cursor: pointer;
 }


### PR DESCRIPTION
<img width="894" height="636" alt="image" src="https://github.com/user-attachments/assets/dd1cc346-4b95-4f24-a6ee-06ff779a80dd" />
