### PR TITLE
fix: file upload preview button shows CHOOSE_FILE instead of label

### DIFF
--- a/public/locales/ar/design/core.json
+++ b/public/locales/ar/design/core.json
@@ -31,6 +31,7 @@
   "back_to_design": "العودة إلى التصميم",
   "cancel": "إلغاء",
   "confirm": "تأكيد",
+  "choose_file": "اختر ملفًا",
   "choose_image": "اختر صورة",
   "columns": "الأعمدة",
   "columns_number": "رقم الأعمدة",

--- a/public/locales/de/design/core.json
+++ b/public/locales/de/design/core.json
@@ -29,6 +29,7 @@
   "back_to_design": "Zurück zum Design",
   "cancel": "stornieren",
   "confirm": "Bestätigen Sie",
+  "choose_file": "Datei auswählen",
   "choose_image": "Bild auswählen",
   "columns": "Spalten",
   "columns_number": "Spaltennummer",

--- a/public/locales/en/design/core.json
+++ b/public/locales/en/design/core.json
@@ -29,6 +29,7 @@
   "back_to_design": "Back to design",
   "cancel": "Cancel",
   "confirm": "Confirm",
+  "choose_file": "Choose File",
   "choose_image": "Choose Image",
   "columns": "Columns",
   "columns_number": "Columns Number",

--- a/public/locales/es/design/core.json
+++ b/public/locales/es/design/core.json
@@ -27,6 +27,7 @@
   "background_color": "Color de Fondo",
   "bytes": "Bytes",
   "cancel": "Cancelar",
+  "choose_file": "Elegir Archivo",
   "choose_image": "Elegir Imagen",
   "collapse_groups": "Reordenar Páginas",
   "collapse_none": "Ninguno",

--- a/public/locales/fr/design/core.json
+++ b/public/locales/fr/design/core.json
@@ -27,6 +27,7 @@
   "background_color": "Couleur de Fond",
   "bytes": "Bytes",
   "cancel": "Annuler",
+  "choose_file": "Choisir un Fichier",
   "choose_image": "Choisir une Image",
   "collapse_groups": "Réorganiser les Pages",
   "collapse_none": "Aucun",

--- a/public/locales/nl/design/core.json
+++ b/public/locales/nl/design/core.json
@@ -27,6 +27,7 @@
   "background_color": "Achtergrondkleur",
   "bytes": "Bytes",
   "cancel": "Annuleren",
+  "choose_file": "Bestand Kiezen",
   "choose_image": "Afbeelding Kiezen",
   "collapse_groups": "Pagina's Herschikken",
   "collapse_none": "Geen",

--- a/public/locales/pt/design/core.json
+++ b/public/locales/pt/design/core.json
@@ -27,6 +27,7 @@
   "background_color": "Cor de Fundo",
   "bytes": "Bytes",
   "cancel": "Cancelar",
+  "choose_file": "Escolher Arquivo",
   "choose_image": "Escolher Imagem",
   "collapse_groups": "Reordenar Páginas",
   "collapse_none": "Nenhum",


### PR DESCRIPTION
<img width="787" height="139" alt="image" src="https://github.com/user-attachments/assets/078e190d-24c3-4f2c-a2e2-9e8ff93bc89f" />
