### PR TITLE
perf: skip rendering question body while dragging

### DIFF
--- a/src/components/Question/QuestionDesign.jsx
+++ b/src/components/Question/QuestionDesign.jsx
@@ -249,6 +249,7 @@ function QuestionDesign({
         </Box>
       )}
 
+    {!isDragging &&
       <QuestionDesignBody
         code={code}
         type={type}
@@ -256,6 +257,7 @@ function QuestionDesign({
         designMode={designMode}
         langInfo={langInfo}
       />
+    }
       <ErrorDisplay code={code} />
     </div>
   );


### PR DESCRIPTION
## Summary

While a question card is being dragged in the survey designer, the card container already drops to `opacity: 0.2` with a dotted placeholder border (see the `isDragging` styling in `QuestionDesign.jsx`), so its body content is not actually visible during the drag.

Despite that, the full `QuestionDesignBody` (answer options, sub-editors, etc.) kept mounting and re-rendering for the entire duration of the drag — wasted work that can make dragging feel heavy on larger questions.

## Change

Gate `QuestionDesignBody` on `!isDragging` so the body is unmounted while the card is being dragged and remounts once the drop completes.

```jsx
{!isDragging &&
  <QuestionDesignBody
    code={code}
    type={type}
    t={t}
    designMode={designMode}
    langInfo={langInfo}
  />
}
```

## Notes

- The question title/description and the drag handle remain rendered, so the dragged card keeps its outline and grab affordance.
- `ErrorDisplay` is unchanged and still renders.