### PR TITLE
feat: make survey card meta icons clickable shortcuts

### DIFF
--- a/src/components/manage/Survey/index.jsx
+++ b/src/components/manage/Survey/index.jsx
@@ -368,7 +368,17 @@ const Survey = ({
                       title={t("label.unpublished_changes")}
                       showIcon={false}
                     >
-                      <div className={styles.surveyIcon}>
+                      <div
+                        className={styles.surveyIcon}
+                        style={isAdmin ? undefined : { cursor: "default" }}
+                        {...(isAdmin && {
+                          onClick: (e) => {
+                            e.stopPropagation();
+                            dispatch(setDesignModeToDesign());
+                            navigate(`/edit-survey/${survey.id}`);
+                          },
+                        })}
+                      >
                         <WarningIcon sx={ICON_SIZE} />
                       </div>
                     </CustomTooltip>
@@ -380,34 +390,20 @@ const Survey = ({
                     count: survey.completeResponseCount,
                   })}
                 >
-                  <div className={styles.surveyIcon}>
+                  <div
+                    className={styles.surveyIcon}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      dispatch(setDesignModeToDesign());
+                      navigate(`/responses/${survey.id}`);
+                    }}
+                  >
                     <Badge
                       badgeContent={survey.completeResponseCount}
                       color="primary"
                       sx={BADGE_SX}
                     >
                       <TableRowsIcon sx={ICON_SIZE} />
-                    </Badge>
-                  </div>
-                </CustomTooltip>
-
-                <CustomTooltip
-                  showIcon={false}
-                  title={
-                    survey.surveyQuota > 0
-                      ? t("label.quota", { count: survey.surveyQuota })
-                      : t("label.no_quota")
-                  }
-                >
-                  <div className={styles.surveyIcon}>
-                    <Badge
-                      badgeContent={
-                        survey.surveyQuota > 0 ? survey.surveyQuota : 0
-                      }
-                      color="primary"
-                      sx={BADGE_SX}
-                    >
-                      <NumbersIcon sx={ICON_SIZE} />
                     </Badge>
                   </div>
                 </CustomTooltip>


### PR DESCRIPTION
## What

Makes the meta icons on the survey card (Dashboard list) functional instead of merely informational. They already had `cursor: pointer` + hover-scale styling but did nothing on click.

- **Responses badge** (`TableRowsIcon`) → navigates to the survey's **Responses** page (`/responses/:id`). Clickable for everyone, always — even at 0 completed responses (the page still shows the empty state, analytics/export, and incomplete responses). This also gives **admins** a responses shortcut they didn't have on the card before.
- **Unpublished-changes warning** (`WarningIcon`) → navigates to **Settings** (`/edit-survey/:id`), which opens directly on the default-expanded **Publish/Launch** section. Clickable for **admins only**, since only admins can publish and non-admins are redirected to Responses by the existing `landingTab` route guard. For non-admins it stays a plain info icon (`cursor: default`, no handler).

Both handlers call `e.stopPropagation()` and `dispatch(setDesignModeToDesign())` before navigating, matching the card's existing action buttons. The admin gate uses a conditional spread (`{...(isAdmin && { onClick })}`) so the JSX stays a single block.

Also removes the survey **quota** meta icon (`NumbersIcon` badge).

## Notes
- The `NumbersIcon` import is now unused after the quota-icon removal — candidate for a follow-up cleanup.

## How to test
1. Open the Dashboard survey list as a **survey admin**.
2. Click a card's responses icon → lands on `/responses/{id}`; verify it works on a card with **0** responses too. Confirm the click doesn't trigger any card-level navigation.
3. On a card with unpublished changes (status ≠ closed, `latestVersion.published === false`), click the warning icon → lands on `/edit-survey/{id}` with the Publish/Launch section at the top.
4. As an **analyst** (non-admin): warning icon shows but is not clickable (default cursor); responses icon still navigates.