### PR TITLE
feat: scroll to moved page in setup panel

### DIFF
--- a/src/components/design/ContentPanel/index.jsx
+++ b/src/components/design/ContentPanel/index.jsx
@@ -234,13 +234,20 @@ function ContentPanel({ designMode }, ref) {
     if (lastAddedComponent && virtuosoRef.current && !skipScroll) {
       const performScroll = () => {
         if (lastAddedComponent.type === "group") {
-          // Calculate the exact index of the newly added group
-          const groupBaseIndex = lastAddedComponent.index * 2; // Assuming each group has a drop area before and after
-          virtuosoRef.current.scrollToIndex({
-            index: groupBaseIndex + 1,
-            behavior: "smooth",
-            align: "start",
-          });
+          // Find the exact list position of the group (accounts for the
+          // optional leading drop area when no welcome page exists).
+          const itemIndex = items.findIndex(
+            (it) =>
+              it.name === ELEMENTS.GROUP &&
+              it.index === lastAddedComponent.index
+          );
+          if (itemIndex !== -1) {
+            virtuosoRef.current.scrollToIndex({
+              index: itemIndex,
+              behavior: "smooth",
+              align: "start",
+            });
+          }
         } else if (lastAddedComponent.type === "question") {
           // Calculate the exact index for the newly added question
           const groupBaseIndex = lastAddedComponent.groupIndex * 2; // Groups and their drop areas

--- a/src/state/design/designState.js
+++ b/src/state/design/designState.js
@@ -865,6 +865,8 @@ export const designState = createSlice({
         case "reorder_groups":
           reorderGroups(state.Survey, payload);
           state.index = buildCodeIndex(state);
+          state.skipScroll = false;
+          state.lastAddedComponent = { type: "group", index: payload.toIndex };
           break;
         case "reorder_answers":
           reorderAnswers(state, payload);


### PR DESCRIPTION
## What

When a page is moved up/down via the Setup Panel's Move Page controls (added in #264), the content panel now smoothly scrolls the moved page into view and briefly highlights it — the same flash already used when adding a page.

## Why

Previously, clicking Move Page up/down reordered the page but the content panel stayed put, so the user lost track of where the page went.

The `onDrag` reducer set `state.skipScroll = true` unconditionally and never updated `lastAddedComponent` for the `reorder_groups` case, so ContentPanel's existing smooth-scroll effect never fired for moves.

## Changes

- **`state/design/designState.js`** — in the `onDrag` `reorder_groups` case, clear `skipScroll` and set `lastAddedComponent = { type: "group", index: payload.toIndex }`. This re-triggers ContentPanel's existing `scrollToIndex({ behavior: "smooth" })` effect and applies the existing highlight flash. Other reorder types are unaffected.
- **`components/design/ContentPanel/index.jsx`** — the group scroll branch now resolves the exact virtual-list position from the `items` array instead of the `index * 2 + 1` heuristic, which mistargeted the page (scrolling it out of view) when a welcome page is present. Also improves the add-page scroll.

## Testing

- Open a survey with several pages in the design editor → select a page → Setup Panel → Move Page up/down.
- Verify the content panel smoothly scrolls the moved page to the top of the viewport and the page briefly flashes.
- Edge cases verified: surveys with/without a welcome page, first page (up disabled), last page (down disabled), and that adding a page still scrolls correctly.