### PR TITLE
fix: enable add column on icon choice array questions

### DIFF
--- a/src/components/Questions/SCQArray/SCQIconArrayDesign.jsx
+++ b/src/components/Questions/SCQArray/SCQIconArrayDesign.jsx
@@ -68,7 +68,7 @@ function SCQIconArrayDesign(props) {
           <Button
             size="small"
             onClick={(e) =>
-              dispatch(addNewAnswer({ code: props.code, type: "column" }))
+              dispatch(addNewAnswer({ questionCode: props.code, type: "column" }))
             }
           >
             {t("add_column")}


### PR DESCRIPTION
## Problem
On the **Icon choice array** (`scq_icon_array`) question type, the **Add column** button in the survey editor did nothing. Adding a row worked fine.

## Root cause
The "Add column" handler dispatched the action with the wrong payload key:

```js
// src/components/Questions/SCQArray/SCQIconArrayDesign.jsx
dispatch(addNewAnswer({ code: props.code, type: "column" }))   // ❌ key was `code`
```

The `addNewAnswer` reducer reads `action.payload.questionCode` and then dereferences `state[questionCode].children` (`src/state/design/designState.js`). With `questionCode` undefined, the reducer threw a `TypeError`, so the dispatch failed and no column was added.

The sibling **Add row** handler in the same file (and both handlers in `ArrayDesign.jsx`) already used the correct `questionCode` key — which is why rows worked but columns didn't.

## Fix
Rename the payload key `code` → `questionCode` so the column handler matches the row handler and the reducer's contract. One-line change.

## Verification
1. `npm start` and open the survey editor.
2. Add/open an **Icon choice array** question.
3. Click **Add column** → a new icon column appears in the header row (no console error).
4. **Add row** still works (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
