### PR TITLE
fix: adapt date/time picker popups to survey theme

### DIFF
--- a/src/components/Questions/DateTime/DateTimeQuestion.jsx
+++ b/src/components/Questions/DateTime/DateTimeQuestion.jsx
@@ -18,6 +18,15 @@ function DateTimeQuestion(props) {
   const theme = useTheme();
   const { i18n } = useTranslation(NAMESPACES.RUN);
 
+  // Adapt the picker popup to the survey theme so its text stays legible on both
+  // light and dark survey themes (instead of a hardcoded white background).
+  const pickerPaperProps = {
+    sx: {
+      backgroundColor: theme.palette.background.paper,
+      color: theme.palette.text.primary,
+    },
+  };
+
   const state = useSelector((state) => {
     let own = state.runState.values[props.component.qualifiedCode];
     let show_errors = state.runState.values.Survey.show_errors;
@@ -82,14 +91,7 @@ function DateTimeQuestion(props) {
                 " " +
                 (props.component.fullDayFormat ? "HH:mm" : "hh:mm A")
               }
-              PaperProps={{
-                sx: {
-                  backgroundColor: 'white',
-                  "& .MuiPickersDay-root": {
-                    backgroundColor: 'white',
-                  },
-                },
-              }}
+              PaperProps={pickerPaperProps}
 
               ampm={props.component.fullDayFormat ? false : true}
               openTo="year"
@@ -135,14 +137,7 @@ function DateTimeQuestion(props) {
             value={state.value}
             error={state.invalid}
             onChange={handleDateChange}
-            PaperProps={{
-              sx: {
-                backgroundColor: 'white',
-                "& .MuiPickersDay-root": {
-                  backgroundColor: 'white',
-                },
-              },
-            }}
+            PaperProps={pickerPaperProps}
           />
         ) : (
           <DatePicker
@@ -167,14 +162,7 @@ function DateTimeQuestion(props) {
                 )
                 : undefined
             }
-            PaperProps={{
-              sx: {
-                backgroundColor: 'white',
-                "& .MuiPickersDay-root": {
-                  backgroundColor: 'white',
-                },
-              },
-            }}
+            PaperProps={pickerPaperProps}
             maxDate={
               props.component.maxDate
                 ? window.QlarrScripts.dateStringToDate(


### PR DESCRIPTION
## Problem
In survey **run** and **preview** modes, the date/time picker popups (`DatePicker`, `TimePicker`, `DateTimePicker`) hardcoded a white background. When a survey uses a dark theme (dark background + light text color), the popup stayed white while the text kept the survey's **light** `text.primary` color — so the year/day/time text was effectively invisible.

## Cause
The run/preview theme is built by `defualtTheme(surveyTheme)` and correctly sets `palette.mode`, `palette.background.paper`, and `palette.text.primary` from the survey's colors. But each picker passed `PaperProps={{ sx: { backgroundColor: 'white', ... } }}`, overriding the themed paper color and breaking contrast on dark themes. (The run/preview theme also doesn't include the global component overrides, so the fix must live in the picker component itself.)

## Fix
In `DateTimeQuestion.jsx`, replace the three hardcoded `PaperProps` blocks with a single shared object driven by the survey theme:

```jsx
const pickerPaperProps = {
  sx: {
    backgroundColor: theme.palette.background.paper,
    color: theme.palette.text.primary,
  },
};
```

Once the popup is no longer forced white, every internal picker surface (year/day grid, calendar header, day-of-week labels, clock, selected pill) derives its colors from the correctly-set `palette.mode` / `palette.text`, so it renders legibly in both light and dark survey themes.

Scope is limited to the respondent-facing picker; the manage page and logic-builder pickers (admin light theme) are unaffected.

## Verification
1. `npm start`, set a dark survey theme in Design → Theming (dark background/paper + light text), add date / time / date_time questions.
2. Preview/run the survey and open each picker — year grid, month/day grid, header arrows, day-of-week labels, clock, and AM/PM toggle should all be readable; the selected pill text legible.
3. Repeat with a light theme to confirm no regression.