### PR TITLE
fix: date/time picker popups overflowing into the design sidebar

### DIFF
--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateInput.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import { DATE_FORMATS } from '../../config/constants';
+import { DATE_FORMATS, PICKER_POPPER_PROPS } from '../../config/constants';
 import styles from '../../QlarrLogicBuilder.module.css';
 import { getCompactTextFieldProps } from '../../utils/inputProps';
 
@@ -20,6 +20,7 @@ export const DateInput = React.memo(function DateInput({ value, onChange, t, com
         onChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
       }}
       inputFormat={DATE_FORMATS.DATE_DISPLAY}
+      PopperProps={PICKER_POPPER_PROPS}
       renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateTimeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/DateTimeInput.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import { DATE_FORMATS } from '../../config/constants';
+import { DATE_FORMATS, PICKER_POPPER_PROPS } from '../../config/constants';
 import styles from '../../QlarrLogicBuilder.module.css';
 import { getCompactTextFieldProps } from '../../utils/inputProps';
 
@@ -20,6 +20,7 @@ export const DateTimeInput = React.memo(function DateTimeInput({ value, onChange
         onChange(newValue ? newValue.format(DATE_FORMATS.DATETIME_VALUE) : '');
       }}
       inputFormat={DATE_FORMATS.DATETIME_DISPLAY}
+      PopperProps={PICKER_POPPER_PROPS}
       renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import { FIELD_TYPES, DATE_FORMATS } from '../../config/constants';
+import { FIELD_TYPES, DATE_FORMATS, PICKER_POPPER_PROPS } from '../../config/constants';
 import { getCompactTextFieldProps } from '../../utils/inputProps';
 import { isRangeInverted } from '../../utils/rangeValidation';
 import styles from '../../QlarrLogicBuilder.module.css';
@@ -83,6 +83,7 @@ export const RangeInput = React.memo(function RangeInput({ fieldType, value, onC
               handleMinChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
             }}
             inputFormat={DATE_FORMATS.DATE_DISPLAY}
+            PopperProps={PICKER_POPPER_PROPS}
             renderInput={(params) => (
               <TextField
                 {...params}
@@ -100,6 +101,7 @@ export const RangeInput = React.memo(function RangeInput({ fieldType, value, onC
               handleMaxChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
             }}
             inputFormat={DATE_FORMATS.DATE_DISPLAY}
+            PopperProps={PICKER_POPPER_PROPS}
             renderInput={(params) => (
               <TextField
                 {...params}

--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/TimeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/TimeInput.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 import { TimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import { DATE_FORMATS } from '../../config/constants';
+import { DATE_FORMATS, PICKER_POPPER_PROPS } from '../../config/constants';
 import styles from '../../QlarrLogicBuilder.module.css';
 import { getCompactTextFieldProps } from '../../utils/inputProps';
 
@@ -20,6 +20,7 @@ export const TimeInput = React.memo(function TimeInput({ value, onChange, t, com
         onChange(newValue ? newValue.format(DATE_FORMATS.TIME_VALUE) : '');
       }}
       inputFormat={DATE_FORMATS.TIME_DISPLAY}
+      PopperProps={PICKER_POPPER_PROPS}
       renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );

--- a/src/components/design/setup/logic/QlarrLogicBuilder/config/constants.js
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/config/constants.js
@@ -38,3 +38,10 @@ export const DATE_FORMATS = {
   TIME_VALUE: 'HH:mm:ss',
   DATETIME_VALUE: 'YYYY-MM-DD HH:mm:ss',
 };
+
+/**
+ * Popper props shared by all logic-builder date/time pickers.
+ * `bottom-start` anchors the popup to the field's start edge so it opens toward
+ * the canvas and never overflows left into the narrow design sidebar.
+ */
+export const PICKER_POPPER_PROPS = { placement: 'bottom-start' };


### PR DESCRIPTION
## Problem

In the survey design editor, opening a date/time picker inside the **Logic → "Show when"** panel made the popup (calendar/clock) extend **left past the narrow setup panel and overlap the left icon sidebar** — partially hidden behind it.

## Root cause

The logic-builder pickers passed no `PopperProps`. In `@mui/x-date-pickers@5.0.20`, `PickersPopper` sets no default `placement`, so MUI `Popper` falls back to `bottom` (centered under the field). In the narrow `22rem` setup panel (~296px of content beside the 56px sidebar), a ~256–320px popup centered under a near-full-width field overflows left. The popup z-index (`theme.zIndex.modal` = 1300) is below the sidebar's `z-index: 9999`, so the overflowing part is painted behind the sidebar.

## Fix

Set `placement: 'bottom-start'` on every logic-builder picker via a single shared `PICKER_POPPER_PROPS` constant. The popup now left-aligns to its field (clear of the 56px sidebar) and opens toward the canvas. `bottom-start` is direction-aware, so RTL (Arabic) opens toward the canvas too.

Scope is intentionally local to the logic builder — respondent-facing `DateTimeQuestion` and the `SurveyActiveFromTo` manage dialog (both in wide layouts, no bug) are untouched.

## Changes
- `config/constants.js` — add `PICKER_POPPER_PROPS = { placement: 'bottom-start' }`
- `DateInput`, `TimeInput`, `DateTimeInput`, `RangeInput` (both from/to date pickers) — pass `PopperProps={PICKER_POPPER_PROPS}`

## Verification
1. Open the design editor, add a condition referencing a date/time/datetime question (incl. a "Between" date range).
2. Open each picker — the popup is left-aligned to the field and opens over the canvas, fully clear of the sidebar.
3. Switch to Arabic (RTL) and confirm it still opens toward the canvas.