### PR TITLE
feat: open upload picker when clicking an image item in the designer

### DIFF
--- a/src/components/DynamicSvg/index.jsx
+++ b/src/components/DynamicSvg/index.jsx
@@ -8,6 +8,7 @@ function DynamicSvg({
   onIconClick,
   opacity = 1,
   isSelected = false,
+  inDesign = false,
   theme,
 }) {
   const [svgContent, setSvgContent] = useState("");
@@ -28,6 +29,7 @@ function DynamicSvg({
         maxHeight: maxHeight,
         maxWidth: maxHeight,
         height: imageHeight,
+        cursor : inDesign ? "pointer" : "inherit",
         aspectRatio: "1",
         padding: "2px",
         width: imageHeight,

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -94,7 +94,7 @@ function IconChoiceItemDesign({
             code: qualifiedCode,
             key: "icon",
             value: response.name,
-          })
+          }),
         );
       })
       .catch((error) => {
@@ -119,7 +119,7 @@ function IconChoiceItemDesign({
       },
       collect: (monitor) => monitor.isDragging(),
     },
-    [index]
+    [index],
   );
 
   const [{ handlerId }, drop] = useDrop({
@@ -182,7 +182,7 @@ function IconChoiceItemDesign({
             id: item.draggableId,
             fromIndex: dragIndex,
             toIndex: hoverIndex,
-          })
+          }),
         );
 
         // Note: we're mutating the monitor item here!
@@ -274,7 +274,7 @@ function IconChoiceItemDesign({
                       setup({
                         code: qualifiedCode,
                         rules: setupOptions("options"),
-                      })
+                      }),
                     );
                   }}
                 >
@@ -292,6 +292,7 @@ function IconChoiceItemDesign({
           )}
           <div className={styles.iconCenter}>
             <DynamicSvg
+              inDesign={true}
               theme={theme}
               onIconClick={() => setIconSelectorOpen(true)}
               imageHeight={imageHeight + "px"}

--- a/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
+++ b/src/components/Questions/Iconchoice/IconChoiceItemDesign.jsx
@@ -57,15 +57,8 @@ function IconChoiceItemDesign({
     return type == "add" ? undefined : state.designState[qualifiedCode];
   });
   const onMainLang = langInfo.lang === langInfo.mainLang;
-  const lang = langInfo.lang;
 
   const svgIconName = answer?.resources?.icon;
-
-  const content = type == "add" ? undefined : answer.content?.[lang]?.["label"];
-
-  const icon = type == "add" ? undefined : answer.icon;
-
-  const isRtl = rtlLanguage.includes(lang);
 
   const mainContent =
     type == "add" ? undefined : answer.content?.[langInfo.mainLang]?.["label"];
@@ -300,6 +293,7 @@ function IconChoiceItemDesign({
           <div className={styles.iconCenter}>
             <DynamicSvg
               theme={theme}
+              onIconClick={() => setIconSelectorOpen(true)}
               imageHeight={imageHeight + "px"}
               svgUrl={svgIconName ? buildResourceUrl(svgIconName) : undefined}
             />

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx
@@ -46,6 +46,7 @@ function ImageChoiceItemDesign({
   const dispatch = useDispatch();
   const theme = useTheme();
   const ref = useRef();
+  const fileInputRef = useRef();
   const [isUploading, setUploading] = useState(false);
   const { guard, modal } = useReleaseGuard();
 
@@ -242,13 +243,27 @@ function ImageChoiceItemDesign({
           />
         )}
         <div
-          className={`${styles.imageContainer} ${styles.imageContainerDynamic}`}
+          className={`${styles.imageContainer} ${styles.imageContainerDynamic} ${
+            inDesign(designMode) ? styles.clickableImage : ""
+          }`}
           style={{
             "--qlarr-aspect-padding": 100 / imageAspectRatio + "%",
             "--qlarr-bg-image": backgroundImage,
           }}
           ref={ref}
           data-handler-id={handlerId}
+          title={inDesign(designMode) ? t("replace_image") : undefined}
+          onClick={
+            inDesign(designMode)
+              ? (e) => {
+                  // Only trigger when the image area itself is clicked,
+                  // not the overlaid buttons / drag handle.
+                  if (e.target === e.currentTarget) {
+                    fileInputRef.current?.click();
+                  }
+                }
+              : undefined
+          }
         >
           {inDesign(designMode) && (
             <div className={`${btnStyles.buttonContainers} ${styles.buttonContainersAbsolute}`}>
@@ -303,6 +318,7 @@ function ImageChoiceItemDesign({
                 >
                   <PhotoCamera />
                   <input
+                    ref={fileInputRef}
                     hidden
                     id={`file-input-${qualifiedCode}`}
                     accept="image/*"

--- a/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
+++ b/src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css
@@ -62,3 +62,7 @@
   padding-top: var(--qlarr-aspect-padding);
   background-image: var(--qlarr-bg-image);
 }
+
+.clickableImage {
+  cursor: pointer;
+}

--- a/src/components/Questions/SCQArray/SCQIconArrayDesign.jsx
+++ b/src/components/Questions/SCQArray/SCQIconArrayDesign.jsx
@@ -294,6 +294,7 @@ function SCQArrayRowDesign({
           >
             <DynamicSvg
               opacity={0.2}
+              inDesign={true}
               theme={theme}
               onIconClick={() => {}}
               imageHeight="64px"
@@ -466,6 +467,7 @@ function SCQArrayHeaderDesign({
         <DynamicSvg
           onIconClick={() => setIconSelectorOpen(true)}
           theme={theme}
+          inDesign={true}
           imageHeight="64px"
           svgUrl={icon ? buildResourceUrl(icon) : undefined}
         />


### PR DESCRIPTION
## What

In the survey designer, clicking an **image item** now opens the file picker to upload/replace the image. Previously, clicking the image did nothing — you had to find and click the small photo (camera) button overlaid on the item.

This applies to all image-based question types that share the item component: **image ranking**, **image MCQ**, and **image SCQ**.

## How

- Reuses the existing upload pipeline unchanged: `designService.uploadResource(file)` → `dispatch(changeResources({ key: "image" }))`. No new service, action, or endpoint.
- A new `fileInputRef` is wired to the existing hidden `<input type="file">`; the image container's `onClick` triggers it.
- The click is gated to design mode (`inDesign(designMode)`), matching where the upload button already appears.
- An `e.target === e.currentTarget` guard ensures the picker only opens when the **image area itself** is clicked — not the overlaid drag handle, delete, build, or photo buttons (those sit in a top strip and already `stopPropagation`).
- Added a `cursor: pointer` affordance and a `Replace Image` tooltip for discoverability.

## Files

- `src/components/Questions/Imagechoice/ImageChoiceItemDesign.jsx`
- `src/components/Questions/Imagechoice/ImageChoiceItemDesign.module.css`

## Testing

1. Open a survey in the designer (Design mode).
2. Add an **Image Ranking** question and click an item's image → the file picker opens; selecting an image replaces it.
3. Confirm the same for image MCQ / SCQ items.
4. Confirm the drag handle, delete, build, and photo buttons still behave as before (no double-trigger).