### PR TITLE
fix: conditional visibility operators for date/time questions

### DIFF
--- a/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/components/ValueInput/RangeInput.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
-import { DatePicker } from '@mui/x-date-pickers';
+import { DatePicker, TimePicker, DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { FIELD_TYPES, DATE_FORMATS } from '../../config/constants';
 import { getCompactTextFieldProps } from '../../utils/inputProps';
@@ -100,6 +100,98 @@ export const RangeInput = React.memo(function RangeInput({ fieldType, value, onC
               handleMaxChange(newValue ? newValue.format(DATE_FORMATS.DATE_VALUE) : '');
             }}
             inputFormat={DATE_FORMATS.DATE_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...toProps}
+                sx={{ ...toProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
+          />
+        </div>
+        {errorElement}
+      </div>
+    );
+  }
+
+  // Time range
+  if (fieldType === FIELD_TYPES.TIME) {
+    const fromProps = getCompactTextFieldProps(compact, t('logic_builder.from'));
+    const toProps = getCompactTextFieldProps(compact, t('logic_builder.to'));
+    return (
+      <div className={styles.rangeInputWrapper}>
+        <div className={styles.rangeInput}>
+          <TimePicker
+            label={compact ? undefined : t('logic_builder.from')}
+            value={min ? dayjs(`2000-01-01 ${min}`) : null}
+            onChange={(newValue) => {
+              handleMinChange(newValue ? newValue.format(DATE_FORMATS.TIME_VALUE) : '');
+            }}
+            inputFormat={DATE_FORMATS.TIME_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...fromProps}
+                sx={{ ...fromProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
+          />
+          <span className={styles.rangeSeparator}>-</span>
+          <TimePicker
+            label={compact ? undefined : t('logic_builder.to')}
+            value={max ? dayjs(`2000-01-01 ${max}`) : null}
+            onChange={(newValue) => {
+              handleMaxChange(newValue ? newValue.format(DATE_FORMATS.TIME_VALUE) : '');
+            }}
+            inputFormat={DATE_FORMATS.TIME_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...toProps}
+                sx={{ ...toProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
+          />
+        </div>
+        {errorElement}
+      </div>
+    );
+  }
+
+  // DateTime range
+  if (fieldType === FIELD_TYPES.DATETIME) {
+    const fromProps = getCompactTextFieldProps(compact, t('logic_builder.from'));
+    const toProps = getCompactTextFieldProps(compact, t('logic_builder.to'));
+    return (
+      <div className={styles.rangeInputWrapper}>
+        <div className={styles.rangeInput}>
+          <DateTimePicker
+            label={compact ? undefined : t('logic_builder.from')}
+            value={min ? dayjs(min) : null}
+            onChange={(newValue) => {
+              handleMinChange(newValue ? newValue.format(DATE_FORMATS.DATETIME_VALUE) : '');
+            }}
+            inputFormat={DATE_FORMATS.DATETIME_DISPLAY}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                {...fromProps}
+                sx={{ ...fromProps.sx, flex: 1, minWidth: 0 }}
+                error={inverted}
+              />
+            )}
+          />
+          <span className={styles.rangeSeparator}>-</span>
+          <DateTimePicker
+            label={compact ? undefined : t('logic_builder.to')}
+            value={max ? dayjs(max) : null}
+            onChange={(newValue) => {
+              handleMaxChange(newValue ? newValue.format(DATE_FORMATS.DATETIME_VALUE) : '');
+            }}
+            inputFormat={DATE_FORMATS.DATETIME_DISPLAY}
             renderInput={(params) => (
               <TextField
                 {...params}

--- a/src/state/design/addInstructions.js
+++ b/src/state/design/addInstructions.js
@@ -1230,10 +1230,7 @@ const jsonToJs = (json, nested, getComponentType, getQuestionType) => {
     case "between":
     case "not_between":
       let type = getComponentType(capture(value[0]));
-      let leftOperand =
-        type == "date" || type == "date_time" || type == "time"
-          ? `+QlarrScripts.sqlDateTimeToDate(${capture(value[0])}.value)`
-          : `${capture(value[0])}.value`;
+      let leftOperand = `${capture(value[0])}.value`;
       if (["==", "!=", "<", "<=", ">", ">="].includes(key)) {
         return `${leftOperand}${key}${capture(value[1], type)}`;
       } else if (key == "between") {
@@ -1326,10 +1323,9 @@ const wrapIfNested = (nested, text) => {
   return (nested ? "(" : "") + text + (nested ? ")" : "");
 };
 
-// Builds a JS expression that coerces a logic-builder SQL date/time string to epoch-ms,
-// matching the (also coerced) stored answer so == / != / < / > / between all compare
-// numbers. The engine's sqlDateTimeToDate requires a full "YYYY-MM-DD HH:MM:SS" string
-// and returns a Date object, hence both the full form and the leading unary "+".
+// Normalizes a logic-builder date/time value to the canonical full SQL string the
+// stored answer uses ("YYYY-MM-DD HH:MM:SS"). That format sorts lexicographically the
+// same as chronologically, so both sides are compared as plain strings.
 const captureSqlDateTime = (value, type) => {
   const sqlDateTime =
     type == "time"
@@ -1337,7 +1333,7 @@ const captureSqlDateTime = (value, type) => {
       : type == "date"
         ? `${value} 00:00:00` // "2025-06-15" -> "2025-06-15 00:00:00"
         : `${value}`; // date_time already "YYYY-MM-DD HH:mm:ss"
-  return `+QlarrScripts.sqlDateTimeToDate(\"${sqlDateTime}\")`;
+  return `\"${sqlDateTime}\"`;
 };
 
 const capture = (value, type) => {

--- a/src/state/design/addInstructions.js
+++ b/src/state/design/addInstructions.js
@@ -1232,7 +1232,7 @@ const jsonToJs = (json, nested, getComponentType, getQuestionType) => {
       let type = getComponentType(capture(value[0]));
       let leftOperand =
         type == "date" || type == "date_time" || type == "time"
-          ? `QlarrScripts.sqlDateTimeToDate(${capture(value[0])}.value)`
+          ? `+QlarrScripts.sqlDateTimeToDate(${capture(value[0])}.value)`
           : `${capture(value[0])}.value`;
       if (["==", "!=", "<", "<=", ">", ">="].includes(key)) {
         return `${leftOperand}${key}${capture(value[1], type)}`;
@@ -1326,7 +1326,27 @@ const wrapIfNested = (nested, text) => {
   return (nested ? "(" : "") + text + (nested ? ")" : "");
 };
 
+// Builds a JS expression that coerces a logic-builder SQL date/time string to epoch-ms,
+// matching the (also coerced) stored answer so == / != / < / > / between all compare
+// numbers. The engine's sqlDateTimeToDate requires a full "YYYY-MM-DD HH:MM:SS" string
+// and returns a Date object, hence both the full form and the leading unary "+".
+const captureSqlDateTime = (value, type) => {
+  const sqlDateTime =
+    type == "time"
+      ? `1970-01-01 ${value}` // "13:00:00" -> "1970-01-01 13:00:00"
+      : type == "date"
+        ? `${value} 00:00:00` // "2025-06-15" -> "2025-06-15 00:00:00"
+        : `${value}`; // date_time already "YYYY-MM-DD HH:mm:ss"
+  return `+QlarrScripts.sqlDateTimeToDate(\"${sqlDateTime}\")`;
+};
+
 const capture = (value, type) => {
+  if (
+    typeof value === "string" &&
+    (type == "time" || type == "date" || type == "date_time")
+  ) {
+    return captureSqlDateTime(value, type);
+  }
   if (type == "time") {
     return `QlarrScripts.sqlDateTimeToDate(\"1970-01-01 ${integerToTime(
       value,

--- a/src/state/design/addInstructions.js
+++ b/src/state/design/addInstructions.js
@@ -1347,18 +1347,6 @@ const capture = (value, type) => {
   ) {
     return captureSqlDateTime(value, type);
   }
-  if (type == "time") {
-    return `QlarrScripts.sqlDateTimeToDate(\"1970-01-01 ${integerToTime(
-      value,
-    )}\")`;
-  } else if (
-    typeof value === "object" &&
-    Object.prototype.toString.call(value) === "[object Date]"
-  ) {
-    return type == "date_time"
-      ? `QlarrScripts.sqlDateTimeToDate(\"${toSqlDateTime(value)}\")`
-      : `QlarrScripts.sqlDateTimeToDate(\"${toSqlDateTimeIgnoreTime(value)}\")`;
-  }
   if (typeof value === "object") {
     return value[Object.keys(value)[0]];
   } else if (typeof value === "string") {
@@ -1366,42 +1354,6 @@ const capture = (value, type) => {
   } else {
     return value;
   }
-};
-
-const integerToTime = (time) => {
-  let hours = Math.floor(time / 3600);
-  let hoursString = hours >= 10 && hours <= 23 ? "" + hours : "0" + hours;
-  let minutes = (time % 3600) / 60;
-  let minutesString =
-    minutes >= 10 && minutes <= 59 ? "" + minutes : "0" + minutes;
-  return hoursString + ":" + minutesString + ":00";
-};
-
-const toSqlDateTime = (date) => {
-  return (
-    date.getFullYear() +
-    "-" +
-    ("00" + (date.getMonth() + 1)).slice(-2) +
-    "-" +
-    ("00" + date.getDate()).slice(-2) +
-    " " +
-    ("00" + date.getHours()).slice(-2) +
-    ":" +
-    ("00" + date.getMinutes()).slice(-2) +
-    ":" +
-    ("00" + date.getSeconds()).slice(-2)
-  );
-};
-
-const toSqlDateTimeIgnoreTime = (date) => {
-  return (
-    date.getFullYear() +
-    "-" +
-    ("00" + (date.getMonth() + 1)).slice(-2) +
-    "-" +
-    ("00" + date.getDate()).slice(-2) +
-    " 00:00:00"
-  );
 };
 
 export const instructionByCode = (component, code) =>


### PR DESCRIPTION
## Problem

Conditional-visibility ("show when") rules referencing a **date / time / datetime** question never evaluate `true` — the dependent question is always hidden for **every** operator (IS, isn't, less than, more than, between, …).

**Repro:** Q1 = time question, Q2 = text; set Q2 "show when Q1 **IS** 1 PM" → in preview Q2 stays hidden even when Q1 = 1 PM.

## Root cause

The relevance rule is serialized to a JS expression by `capture()` in `src/state/design/addInstructions.js`. The QlarrLogicBuilder pickers emit SQL-style **strings** (`"13:00:00"`, `"2025-06-15"`, `"2025-06-15 13:00:00"`), but `capture()` was written for an older builder that emitted integer seconds (time) and JS `Date` objects (date). So e.g. `integerToTime("13:00:00")` does integer math on a string → `NaN` → the comparison value is garbage and never matches.

## Fix

Normalize **both** sides to the canonical zero-padded SQL form the stored answer already uses (`YYYY-MM-DD HH:MM:SS`) and compare them **as plain strings** — that format sorts lexicographically the same as chronologically, so `==`, `!=`, `<`, `<=`, `>`, `>=`, `between` and `not_between` all work.

- `captureSqlDateTime()` builds the full SQL string for the rule value (time → `1970-01-01 HH:mm:ss`, date → `YYYY-MM-DD 00:00:00`, datetime → as-is).
- The left operand is just `Q1.value` (already canonical) — no special-casing.
- Removed the dead legacy `capture()` branches and the now-unused `integerToTime` / local `toSqlDateTime` / `toSqlDateTimeIgnoreTime` helpers.

Generated output for the repro is now simply: `Q1.value=="1970-01-01 13:00:00"`.

This avoids `QlarrScripts.sqlDateTimeToDate()` entirely in the relevance path — and with it the `Date == Date` reference-equality trap (two `Date` objects are never `==`), which is why a Date-based approach would need extra numeric coercion just to make `IS` work.

**`RangeInput.jsx`:** added `TimePicker`/`DateTimePicker` "between" branches so time/datetime ranges get real pickers, matching date/number.

## Verification

Ran the **real** `conditionalRelevanceEquation` from the edited file — **21/21 assertions pass** across all eight operators × time/date/datetime (plus a text sanity check). Files pass an esbuild parse check.

## Follow-ups (out of scope)

- The private `frontend-cloud` fork has the identical buggy serializer and needs the same fix ported.
- No test runner is configured today; a Vitest spec for `jsonToJs`/`capture` would lock this against future picker-format drift.