### PR TITLE
feat: per-input validation for multiple short text inputs

### DIFF
--- a/src/components/Questions/Choice/ChoiceItemDesign.jsx
+++ b/src/components/Questions/Choice/ChoiceItemDesign.jsx
@@ -309,7 +309,9 @@ function ChoiceItemDesign(props) {
                 dispatch(
                   setup({
                     code: props.qualifiedCode,
-                    rules: setupOptions("options"),
+                    rules: setupOptions(
+                      props.type === "text" ? "text_item" : "options",
+                    ),
                   })
                 );
               }}

--- a/src/components/Questions/MultipleText/MultipleText.jsx
+++ b/src/components/Questions/MultipleText/MultipleText.jsx
@@ -80,6 +80,7 @@ function MultipleTextItem({ item }) {
         fullWidth
         onChange={handleChange}
         required={item.validation?.required}
+        inputProps={{ maxLength: item.maxChars || undefined }}
         className={styles.textField}
       />
     </Box>

--- a/src/constants/design.js
+++ b/src/constants/design.js
@@ -233,6 +233,32 @@ export const setupOptions = (type) => {
         },
       ];
 
+    case "text_item":
+      return [
+        {
+          title: "general",
+          key: "general",
+          rules: ["changeCode", "disabled", "maxChars"],
+        },
+        {
+          title: "logic",
+          key: "logic",
+          rules: ["relevance"],
+        },
+        {
+          title: "validation",
+          key: "validation",
+          rules: [
+            "validation_max_char_length",
+            "validation_min_char_length",
+            "validation_pattern",
+            "validation_contains",
+            "validation_not_contains",
+            "custom_validation_rules",
+          ],
+        },
+      ];
+
     case "number":
       return [
         {


### PR DESCRIPTION
## What

Lets each individual input in a **Multiple Short Text** question carry the same *content* validation that the **"other answer"** free-text field has in single/multiple choice questions, configured from that input's own settings panel.

Per input you can now set:
- Max / min character length
- Regex pattern
- Contains / does-not-contain
- Custom validation rules
- Text Field Size (`maxChars`)

## Why

Previously a multiple-text input's settings only exposed `changeCode`, `disabled`, and `relevance` — there was no per-input validation. The only validation was a single question-level "required" toggle.

## How

- **`src/constants/design.js`** — new `setupOptions("text_item")` case: a **General** tab (`changeCode`, `disabled`, `maxChars`), a **Logic** tab (`relevance`), and a **Validation** tab (the content rules above). It mirrors `other_text` but keeps the per-item controls and omits `validation_required`.
- **`src/components/Questions/Choice/ChoiceItemDesign.jsx`** — the per-input settings (wrench) icon now opens `text_item` when the item belongs to a multiple-text question (`props.type === "text"`); scq/mcq/ranking items keep the existing `options` panel.
- **`src/components/Questions/MultipleText/MultipleText.jsx`** — the runtime input respects the per-input `maxChars` via `inputProps={{ maxLength }}`.

The change is purely additive — it reuses the existing validation pipeline (`processValidation` / `validationEquation`) and the per-item `<Validation>` runtime rendering, which already operate on child component codes. No changes to instruction generation.

**"Required" stays a question-level toggle** (unchanged behavior).

## Notes

- A per-input's max-length validation is clamped to 30 until that input's **Text Field Size** (`maxChars`) is raised in its General tab — same behavior as the "other answer" field.

## Testing

- Create a Multiple Short Text question, open an input's settings, and confirm the new General / Logic / Validation tabs appear (no Required toggle).
- Set min/max length, pattern, and a custom rule on one input; configure another differently to confirm independence.
- Take the survey: per-input errors fire under the right input; over-`maxChars` typing is blocked.
- Regression: question-level "required" still makes all inputs required; choice/ranking items still show the old flat settings panel.