### PR TITLE
fix: position close icon in autocomplete manual-entry dialog

### DIFF
--- a/src/components/Questions/AutoComplete/AutoComplete.module.css
+++ b/src/components/Questions/AutoComplete/AutoComplete.module.css
@@ -75,12 +75,6 @@
   width: 50%;
 }
 
-.dialogCloseButton {
-  position: absolute;
-  right: 8px;
-  top: 8px;
-}
-
 .textFieldMarginBottom {
   margin-bottom: 12px;
 }

--- a/src/components/Questions/AutoComplete/AutoCompleteDesign.jsx
+++ b/src/components/Questions/AutoComplete/AutoCompleteDesign.jsx
@@ -217,12 +217,18 @@ function AutoCompleteQuestion({ code, t, onMainLang }) {
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           {t("manual_entry")}
           <IconButton
             aria-label="close"
             onClick={() => setDialogOpen(false)}
-            className={styles.dialogCloseButton}
+            sx={{ color: (theme) => theme.palette.grey[500], mr: -1 }}
           >
             <CloseIcon />
           </IconButton>


### PR DESCRIPTION
## Problem
In the autocomplete question's **Enter Options Manually** dialog, the close (✕) button rendered inline right after the title text instead of in the top-right corner of the title bar.


<img width="428" height="230" alt="image" src="https://github.com/user-attachments/assets/b613d3e2-a955-4e4e-b3bf-f9d6c8c42df3" />

## Root cause
The close button relied on a CSS-module class with `position: absolute`. MUI's `MuiButtonBase-root` sets `position: relative` via Emotion, and those Emotion styles are injected **after** the CSS-module styles in `<head>`. With equal (single-class) specificity, MUI's rule wins the cascade, so `position: absolute` never took effect and the icon stayed inline.

## Fix
- Make `DialogTitle` a flex container (`display: flex; align-items: center; justify-content: space-between`) so the title and close button sit on the same row.
- Style the `IconButton` with the `sx` prop (Emotion-based, immune to CSS-module injection-order issues) and a muted grey color.
- Remove the now-unused `.dialogCloseButton` CSS-module class.

The close button now reliably sits at the right edge of the title bar, vertically centered.

## Testing
- JSX parses cleanly via esbuild.
- Visual: open an autocomplete question → **Manual entry** → confirm the ✕ is at the top-right of the dialog header.