### PR TITLE
fix: reset Show when toggle when last conditional relevance rule is removed

### DIFF
--- a/src/components/design/setup/logic/QlarrLogicBuilder/index.jsx
+++ b/src/components/design/setup/logic/QlarrLogicBuilder/index.jsx
@@ -22,7 +22,11 @@ function InlineLogicBuilderSync({ onChange }) {
   useEffect(() => {
     if (isDirty) {
       const newJsonLogic = treeToJsonLogic(tree);
-      onChangeRef.current({ jsonLogic: newJsonLogic, queryString: '' });
+      onChangeRef.current({
+        jsonLogic: newJsonLogic,
+        queryString: '',
+        isEmpty: tree.children.length === 0,
+      });
     }
   }, [tree, isDirty]);
 

--- a/src/components/design/setup/logic/Relevance/index.jsx
+++ b/src/components/design/setup/logic/Relevance/index.jsx
@@ -59,7 +59,10 @@ function Relevance({ code, t }) {
   };
 
   const onLogicChange = useCallback(
-    ({ jsonLogic }) => setRelevance({ rule: "show_if", logic: jsonLogic }),
+    ({ jsonLogic, isEmpty }) =>
+      isEmpty
+        ? setRelevance({ rule: "show_always", logic: undefined })
+        : setRelevance({ rule: "show_if", logic: jsonLogic }),
     [setRelevance]
   );
 


### PR DESCRIPTION
## Problem

In a question's **Logic** tab, removing the last conditional relevance rule left the **Show when** toggle stuck ON with no conditions.

**Repro:**
1. Select a question → **Logic** tab → enable **Show when**.
2. Add a conditional relevance rule.
3. Remove that rule.

**Expected:** the toggle resets to OFF.
**Actual:** the toggle stayed ON with no rules.

## Root cause

The toggle's checked state is derived purely from `rule === "show_if"`. When the last rule is removed, the inline logic builder fires `onChange` with `jsonLogic: null` (an empty tree converts to `null`), but the handler still saved `rule: "show_if"` — so the toggle stayed ON.

A naive "reset whenever `jsonLogic` is null" fix would break the add flow, because an **in-progress incomplete rule** (e.g. right after clicking *Add Condition*) also produces `null`. The real discriminator is the number of rule rows in the builder tree.

## Fix

- `QlarrLogicBuilder/index.jsx` — the builder's sync effect now reports `isEmpty: tree.children.length === 0` in its `onChange` payload.
- `Relevance/index.jsx` — `onLogicChange` resets relevance to `show_always` (toggle OFF) only when `isEmpty` is true; an incomplete in-progress rule (`children.length > 0`) keeps the toggle ON.

The freshly-enabled empty state stays ON as before, because the builder mounts with `isDirty: false` and its sync effect never fires on mount. `QlarrLogicBuilderInlineWrapper` is consumed only by `Relevance`, so adding a field to the payload has no other call sites.

## Behavior after fix

- Enable toggle (no rules yet): toggle ON, empty builder — unchanged.
- Add Condition / build an incomplete rule: toggle stays ON — unchanged.
- Complete a rule: toggle ON, logic saved — unchanged.
- **Remove the last rule: toggle resets to OFF** — fixed.
- Remove one of several rules: toggle stays ON with remaining rules — unchanged.

## Verification

Manual (no automated test suite covers this component):
1. Question → **Logic** → enable **Show when** → confirm empty builder, toggle ON.
2. **Add Condition**, form a valid rule → toggle ON, rule saved.
3. Delete the rule → toggle flips OFF, builder disappears, no `conditional_relevance` instruction remains.
4. Regression: incomplete rule keeps toggle ON; deleting one of two rules keeps it ON with the remaining rule.